### PR TITLE
Add -no-undefined to the libtool flags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,7 @@ libjsoninclude_HEADERS = \
 	linkhash.h \
 	printbuf.h
 
-libjson_la_LDFLAGS = -version-info 1:0:1
+libjson_la_LDFLAGS = -version-info 1:0:1 -no-undefined
 
 libjson_la_SOURCES = \
 	arraylist.c \


### PR DESCRIPTION
This allows building DLLs for windows - libtool doesn't even
try to do that unless this flag is specified.
