### PR TITLE
Renaming the boolean type to json_bool in json_object.h

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -275,7 +275,7 @@ static int json_object_boolean_to_json_string(struct json_object* jso,
   else return sprintbuf(pb, "false");
 }
 
-struct json_object* json_object_new_boolean(boolean b)
+struct json_object* json_object_new_boolean(json_bool b)
 {
   struct json_object *jso = json_object_new(json_type_boolean);
   if(!jso) return NULL;
@@ -284,7 +284,7 @@ struct json_object* json_object_new_boolean(boolean b)
   return jso;
 }
 
-boolean json_object_get_boolean(struct json_object *jso)
+json_bool json_object_get_boolean(struct json_object *jso)
 {
   if(!jso) return FALSE;
   switch(jso->o_type) {

--- a/json_object.h
+++ b/json_object.h
@@ -21,10 +21,10 @@ extern "C" {
 #define JSON_OBJECT_DEF_HASH_ENTRIES 16
 
 #undef FALSE
-#define FALSE ((boolean)0)
+#define FALSE ((json_bool)0)
 
 #undef TRUE
-#define TRUE ((boolean)1)
+#define TRUE ((json_bool)1)
 
 extern const char *json_number_chars;
 extern const char *json_hex_chars;
@@ -39,7 +39,7 @@ struct json_object_iter
 
 /* forward structure definitions */
 
-typedef int boolean;
+typedef int json_bool;
 typedef struct printbuf printbuf;
 typedef struct lh_table lh_table;
 typedef struct array_list array_list;
@@ -245,26 +245,26 @@ extern int json_object_array_put_idx(struct json_object *obj, int idx,
 extern struct json_object* json_object_array_get_idx(struct json_object *obj,
 						     int idx);
 
-/* boolean type methods */
+/* json_bool type methods */
 
 /** Create a new empty json_object of type json_type_boolean
- * @param b a boolean TRUE or FALSE (0 or 1)
+ * @param b a json_bool TRUE or FALSE (0 or 1)
  * @returns a json_object of type json_type_boolean
  */
-extern struct json_object* json_object_new_boolean(boolean b);
+extern struct json_object* json_object_new_boolean(json_bool b);
 
-/** Get the boolean value of a json_object
+/** Get the json_bool value of a json_object
  *
- * The type is coerced to a boolean if the passed object is not a boolean.
+ * The type is coerced to a json_bool if the passed object is not a json_bool.
  * integer and double objects will return FALSE if there value is zero
  * or TRUE otherwise. If the passed object is a string it will return
  * TRUE if it has a non zero length. If any other object type is passed
  * TRUE will be returned if the object is not NULL.
  *
  * @param obj the json_object instance
- * @returns a boolean
+ * @returns a json_bool
  */
-extern boolean json_object_get_boolean(struct json_object *obj);
+extern json_bool json_object_get_boolean(struct json_object *obj);
 
 
 /* int type methods */

--- a/json_object_private.h
+++ b/json_object_private.h
@@ -28,7 +28,7 @@ struct json_object
   int _ref_count;
   struct printbuf *_pb;
   union data {
-    boolean c_boolean;
+    json_bool c_boolean;
     double c_double;
     int64_t c_int64;
     struct lh_table *c_object;


### PR DESCRIPTION
In building large systems, there are often clashes over the
preferred base type to use for bool/boolean. At least one
experience has been with a 3rd party proprietary library which
can not be changed. In that case, boolean was a synonym for
unsigned char and used widely in packed structures.
