### PR TITLE
Fix missing inttypes.h definitions for Visual Studio 2010 and earliers. ...

### DIFF
--- a/json_inttypes.h
+++ b/json_inttypes.h
@@ -4,13 +4,15 @@
 
 #include "json_config.h"
 
-#if defined(_MSC_VER) && _MSC_VER < 1600
+#if defined(_MSC_VER) && _MSC_VER < 1700
 
 /* Anything less than Visual Studio C++ 10 is missing stdint.h and inttypes.h */
 typedef __int32 int32_t;
 #define INT32_MIN    ((int32_t)_I32_MIN)
 #define INT32_MAX    ((int32_t)_I32_MAX)
 typedef __int64 int64_t;
+#define INT64_MIN    ((int64_t)_I64_MIN)
+#define INT64_MAX    ((int64_t)_I64_MAX)
 #define PRId64 "I64d"
 #define SCNd64 "I64d"
 


### PR DESCRIPTION
...Related to issue #22.
