### PR TITLE
Fixing CPP problem originating from false-positives #error

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -27,7 +27,7 @@ AC_FUNC_VPRINTF
 AC_FUNC_MEMCMP
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
-AC_CHECK_FUNCS(strndup strerror vsnprintf vasprintf open vsyslog strncasecmp)
+AC_CHECK_FUNCS(strndup strerror vsnprintf vasprintf open vsyslog strncasecmp strdup snprintf)
 
 AM_PROG_LIBTOOL
 


### PR DESCRIPTION
Fixing a compile problem that hits the #error in the cpp on the strdup and snprintf. Using the i686-apple-darwin10-gcc-4.2.1 compiler on OSX 10.6 (Snow Leopard).
