### PR TITLE
Added a bunch of missing HAVE_* defines

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -29,6 +29,9 @@
    and to 0 otherwise. */
 #undef HAVE_REALLOC
 
+/* Define to 1 if you have the `snprintf' function. */
+#undef HAVE_SNPRINTF
+
 /* Define to 1 if you have the <stdarg.h> header file. */
 #undef HAVE_STDARG_H
 
@@ -37,6 +40,12 @@
 
 /* Define to 1 if you have the <stdlib.h> header file. */
 #undef HAVE_STDLIB_H
+
+/* Define to 1 if you have the `strcasecmp' function. */
+#undef HAVE_STRCASECMP
+
+/* Define to 1 if you have the `strdup' function. */
+#undef HAVE_STRDUP
 
 /* Define to 1 if you have the `strerror' function. */
 #undef HAVE_STRERROR

--- a/configure.in
+++ b/configure.in
@@ -27,7 +27,7 @@ AC_FUNC_VPRINTF
 AC_FUNC_MEMCMP
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
-AC_CHECK_FUNCS(strndup strerror vsnprintf vasprintf open vsyslog strncasecmp)
+AC_CHECK_FUNCS(strcasecmp strdup strndup strerror snprintf vsnprintf vasprintf open vsyslog strncasecmp)
 
 AM_PROG_LIBTOOL
 

--- a/tests/test_printbuf.c
+++ b/tests/test_printbuf.c
@@ -124,7 +124,7 @@ static void test_sprintbuf(int before_resize)
 	memset(data, 'X', before_resize + 1 + 1);
 	data[before_resize + 1] = '\0';
 	sprintbuf(pb, "%s", data);
-	printf("sprintbuf to just after resize(%d+1): %d, [%s], strlen(buf)=%d\n", before_resize, printbuf_length(pb), pb->buf, strlen(pb->buf));
+	printf("sprintbuf to just after resize(%d+1): %d, [%s], strlen(buf)=%d\n", before_resize, printbuf_length(pb), pb->buf, (int)strlen(pb->buf));
 
 	printbuf_reset(pb);
 	sprintbuf(pb, "plain");


### PR DESCRIPTION
...to fix compilation on Linux with GCC 4.7.1. The issue likely caused by my previous commits related to Visual C++ port of the code.

These changes are required to build the current master of json-c on Linux with GCC.
Apology for not testing my Visual C++ porting changes earlier.
