### PR TITLE
Fix test warning: strlen() returns size_t, not int.

### DIFF
--- a/tests/test_printbuf.c
+++ b/tests/test_printbuf.c
@@ -124,7 +124,7 @@ static void test_sprintbuf(int before_resize)
 	memset(data, 'X', before_resize + 1 + 1);
 	data[before_resize + 1] = '\0';
 	sprintbuf(pb, "%s", data);
-	printf("sprintbuf to just after resize(%d+1): %d, [%s], strlen(buf)=%d\n", before_resize, printbuf_length(pb), pb->buf, strlen(pb->buf));
+	printf("sprintbuf to just after resize(%d+1): %d, [%s], strlen(buf)=%zd\n", before_resize, printbuf_length(pb), pb->buf, strlen(pb->buf));
 
 	printbuf_reset(pb);
 	sprintbuf(pb, "plain");


### PR DESCRIPTION
Prevents a test failure on OpenBSD:
cc -DHAVE_CONFIG_H -I. -I..     -Wall -Wwrite-strings -Werror -std=gnu99 -D_GNU_SOURCE -D_REENTRANT -O2 -pipe -MT test_printbuf.o -MD -MP -MF .deps/test_printbuf.Tpo -c -o test_printbuf.o test_printbuf.c
cc1: warnings being treated as errors
test_printbuf.c: In function 'test_sprintbuf':
test_printbuf.c:127: warning: format '%d' expects type 'int', but argument 5 has type 'size_t'
**\* Error code 1

From the strlen(3) man page:

```
 size_t
 strlen(const char *s);
```

From the printf(3) man page:

"The z modifier, when applied to a d or i conversion, indicates that the
argument is of a signed type equivalent in size to a size_t."
