### PR TITLE
autogen.sh: Add /bin/sh interpreter, honor NOCONFIGURE=1 …

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,2 +1,5 @@
+#!/bin/sh
 autoreconf -v --install || exit 1
-exec ./configure  "$@"
+if test -z "$NOCONFIGURE"; then
+    exec ./configure  "$@"
+fi


### PR DESCRIPTION
First, we should be able to execute as "./autogen.sh".  Second,
add support for NOCONFIGURE=1.  For more information,
see http://people.gnome.org/~walters/docs/build-api.txt
