### PR TITLE
Add an autoconf test to test whether the .section .gnu<warning>

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -1,5 +1,8 @@
 /* config.h.in.  Generated from configure.in by autoheader.  */
 
+/* Define if .gnu.warning accepts long strings. */
+#undef HAS_GNU_WARNING_LONG
+
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #undef HAVE_DLFCN_H
 
@@ -113,9 +116,6 @@
 
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
-
-/* Define to the home page for this package. */
-#undef PACKAGE_URL
 
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION

--- a/configure.in
+++ b/configure.in
@@ -37,6 +37,24 @@ AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_CHECK_FUNCS(strcasecmp strdup strndup strerror snprintf vsnprintf vasprintf open vsyslog strncasecmp)
 
+#check if .section.gnu.warning accepts long strings (for __warn_references)
+AC_LANG_PUSH([C])
+
+AC_MSG_CHECKING([if .gnu.warning accepts long strings])
+AC_LINK_IFELSE([[
+extern void json_object_get();
+__asm__(".section .gnu.json_object_get,\n\t.ascii \"Please link against libjson-c instead of libjson\"\n\t.text");
+
+int main(int c,char* v) {return 0;}
+]], [
+    AC_DEFINE(HAS_GNU_WARNING_LONG, 1, [Define if .gnu.warning accepts long strings.])
+    AC_MSG_RESULT(yes)
+], [
+   AC_MSG_RESULT(no)
+])
+
+AC_LANG_POP([C])
+
 AM_PROG_LIBTOOL
 
 AC_CONFIG_FILES([

--- a/libjson.c
+++ b/libjson.c
@@ -7,11 +7,10 @@
 
 #ifndef __warn_references
 
-#ifdef __GNUC__
-#define __warn_references(sym,msg)                      \
-    __asm(".pushsection .gnu.warning." #sym "\n"            \
-      ".ascii \"" msg "\"\n"                    \
-      ".popsection");
+#if defined(__GNUC__)  && defined (HAS_GNU_WARNING_LONG)
+
+#define __warn_references(sym,msg)                  \
+  __asm__(".section .gnu" #sym ",\n\t.ascii \"" msg "\"\n\t.text");
 
 #else
 #define __warn_references(sym,msg)    /* nothing */


### PR DESCRIPTION
works with the linker on the system, and define _warn_references
to nothing if not.

This fixes #41
