### PR TITLE
Free data in test_printbuf

### DIFF
--- a/tests/test_printbuf.c
+++ b/tests/test_printbuf.c
@@ -143,6 +143,8 @@ static void test_sprintbuf(int before_resize)
 	printf("%d, [%s]\n", printbuf_length(pb), pb->buf);
 
 	printbuf_free(pb);
+	free(data);
+
 	printf("%s: end test\n", __func__);
 }
 


### PR DESCRIPTION
With valgrind-3.5.0 I got error on test_printbuf complaining about non freed memory. Here is a patch.
