### PR TITLE
Optimize json_parse_int64 when sscanf work as expected

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -57,6 +57,24 @@ AC_LANG_POP([C])
 
 AM_PROG_LIBTOOL
 
+AC_MSG_CHECKING([for working sscanf])
+AC_TRY_RUN([
+#include <stdio.h>
+#include <stdint.h>
+#include <errno.h>
+int main(int argc, char *argv[]){
+long i;
+errno=0;
+return (sscanf("1234567890123456789012345","%ld",&i)==1 && errno==ERANGE && i==INT64_MAX ? 0 : 1);
+}],[
+    AC_MSG_RESULT([yes])
+    AC_DEFINE(HAS_SSCANF_ERANGE, 1, [Whether correctly return ERANGE])
+],[
+    AC_MSG_RESULT([no, not working])
+],[
+    AC_MSG_RESULT([no, not found])
+])
+
 AC_CONFIG_FILES([
 Makefile
 json.pc

--- a/json_util.c
+++ b/json_util.c
@@ -145,15 +145,20 @@ int json_object_to_file(char *filename, struct json_object *obj)
 int json_parse_int64(const char *buf, int64_t *retval)
 {
 	int64_t num64;
+#ifndef HAS_SSCANF_ERANGE
 	const char *buf_skip_space;
 	int orig_has_neg;
 	int _errno;
+
 	errno = 0; // sscanf won't always set errno, so initialize
+#endif
+
 	if (sscanf(buf, "%" SCNd64, &num64) != 1)
 	{
 		MC_DEBUG("Failed to parse, sscanf != 1\n");
 		return 1;
 	}
+#ifndef HAS_SSCANF_ERANGE
 	_errno = errno;
 	buf_skip_space = buf;
 	orig_has_neg = 0;
@@ -209,6 +214,7 @@ int json_parse_int64(const char *buf, int64_t *retval)
 		else
 			num64 = INT64_MAX;
 	}
+#endif
 	*retval = num64;
 	return 0;
 }


### PR DESCRIPTION
From callgrind analysis, json_parse_int64 is long because of lot of sscanf / snprintf call

Reading the code, it seems lot of stuff are present to mimic the standard and modern sscanf behavior:
    Set errno to  ERANGE when out of range, and set value to INT64_MIN / INT64_MAX.

This patch detect the correct behavior of sscanf during configure, and so, avoid lot of unuseful code.

From my minimum bench (parsing a 500k string), it reduce time from 0.09s to 0.06s (well the data contains mostly random integers)
