### PR TITLE
escape '\f' in json_escape_str

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -98,6 +98,7 @@ static int json_escape_str(struct printbuf *pb, char *str, int len)
     case '\n':
     case '\r':
     case '\t':
+    case '\f':
     case '"':
     case '\\':
     case '/':
@@ -107,6 +108,7 @@ static int json_escape_str(struct printbuf *pb, char *str, int len)
       else if(c == '\n') printbuf_memappend(pb, "\\n", 2);
       else if(c == '\r') printbuf_memappend(pb, "\\r", 2);
       else if(c == '\t') printbuf_memappend(pb, "\\t", 2);
+      else if(c == '\f') printbuf_memappend(pb, "\\f", 2);
       else if(c == '"') printbuf_memappend(pb, "\\\"", 2);
       else if(c == '\\') printbuf_memappend(pb, "\\\\", 2);
       else if(c == '/') printbuf_memappend(pb, "\\/", 2);


### PR DESCRIPTION
'\f' is a llegal char and should be escape in printbuf
