### PR TITLE
Make json_object_object_add() indicate success or failure, test fix

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -371,7 +371,7 @@ struct lh_table* json_object_get_object(struct json_object *jso)
   }
 }
 
-void json_object_object_add(struct json_object* jso, const char *key,
+int json_object_object_add(struct json_object* jso, const char *key,
 			    struct json_object *val)
 {
 	// We lookup the entry and replace the value, rather than just deleting
@@ -381,13 +381,19 @@ void json_object_object_add(struct json_object* jso, const char *key,
 	existing_entry = lh_table_lookup_entry(jso->o.c_object, (void*)key);
 	if (!existing_entry)
 	{
-		lh_table_insert(jso->o.c_object, strdup(key), val);
-		return;
+		char * keydup = strdup( key );
+		if ( keydup == NULL ) {
+			return -1;
+		}
+
+		return lh_table_insert(jso->o.c_object, keydup, val);
 	}
 	existing_value = (void *)existing_entry->v;
 	if (existing_value)
 		json_object_put(existing_value);
 	existing_entry->v = val;
+
+	return 0;
 }
 
 struct json_object* json_object_object_get(struct json_object* jso, const char *key)

--- a/json_object.h
+++ b/json_object.h
@@ -230,8 +230,11 @@ extern struct lh_table* json_object_get_object(struct json_object *obj);
  * @param obj the json_object instance
  * @param key the object field name (a private copy will be duplicated)
  * @param val a json_object or NULL member to associate with the given field
+ *
+ * @return On success, <code>0</code> is returned.
+ * 	On error, a negative value is returned.
  */
-extern void json_object_object_add(struct json_object* obj, const char *key,
+extern int json_object_object_add(struct json_object* obj, const char *key,
 				   struct json_object *val);
 
 /** Get the json_object associate with a given object field

--- a/linkhash.h
+++ b/linkhash.h
@@ -182,7 +182,8 @@ for(entry = table->head; entry && ((tmp = entry->next) || 1); entry = tmp)
  * @param equal_fn comparison function to compare keys. 2 standard ones defined:
  * lh_ptr_hash and lh_char_hash for comparing pointer values
  * and C strings respectively.
- * @return a pointer onto the linkhash table.
+ * @return On success, a pointer to the new linkhash table is returned.
+ * 	On error, a null pointer is returned.
  */
 extern struct lh_table* lh_table_new(int size, const char *name,
 				     lh_entry_free_fn *free_fn,
@@ -195,7 +196,8 @@ extern struct lh_table* lh_table_new(int size, const char *name,
  * @param size initial table size.
  * @param name table name.
  * @param free_fn callback function used to free memory for entries.
- * @return a pointer onto the linkhash table.
+ * @return On success, a pointer to the new linkhash table is returned.
+ * 	On error, a null pointer is returned.
  */
 extern struct lh_table* lh_kchar_table_new(int size, const char *name,
 					   lh_entry_free_fn *free_fn);
@@ -207,7 +209,8 @@ extern struct lh_table* lh_kchar_table_new(int size, const char *name,
  * @param size initial table size.
  * @param name table name.
  * @param free_fn callback function used to free memory for entries.
- * @return a pointer onto the linkhash table.
+ * @return On success, a pointer to the new linkhash table is returned.
+ * 	On error, a null pointer is returned.
  */
 extern struct lh_table* lh_kptr_table_new(int size, const char *name,
 					  lh_entry_free_fn *free_fn);
@@ -227,6 +230,9 @@ extern void lh_table_free(struct lh_table *t);
  * @param t the table to insert into.
  * @param k a pointer to the key to insert.
  * @param v a pointer to the value to insert.
+ *
+ * @return On success, <code>0</code> is returned.
+ * 	On error, a negative value is returned.
  */
 extern int lh_table_insert(struct lh_table *t, void *k, const void *v);
 
@@ -280,9 +286,31 @@ extern int lh_table_delete_entry(struct lh_table *t, struct lh_entry *e);
  */
 extern int lh_table_delete(struct lh_table *t, const void *k);
 
-
+/**
+ * Prints a message to <code>stdout</code>,
+ * then exits the program with an exit code of <code>1</code>.
+ *
+ * @param msg Message format string, like for <code>printf</code>.
+ * @param ... Format args.
+ *
+ * @deprecated Since it is not a good idea to exit the entire program
+ * 	because of an internal library failure, json-c will no longer
+ * 	use this function internally.
+ * 	However, because its interface is public, it will remain part of
+ * 	the API on the off chance of legacy software using it externally.
+ */
 void lh_abort(const char *msg, ...);
-void lh_table_resize(struct lh_table *t, int new_size);
+
+/**
+ * Resizes the specified table.
+ *
+ * @param t Pointer to table to resize.
+ * @param new_size New table size. Must be positive.
+ *
+ * @return On success, <code>0</code> is returned.
+ * 	On error, a negative value is returned.
+ */
+int lh_table_resize(struct lh_table *t, int new_size);
 
 #ifdef __cplusplus
 }

--- a/tests/test_parse.expected
+++ b/tests/test_parse.expected
@@ -44,7 +44,7 @@ json_tokener_parse_ex(tok, "blue"      ,   6) ... OK: got object of type [string
 json_tokener_parse_ex(tok, "\""        ,   4) ... OK: got object of type [string]: "\""
 json_tokener_parse_ex(tok, "\\"        ,   4) ... OK: got object of type [string]: "\\"
 json_tokener_parse_ex(tok, "\b"        ,   4) ... OK: got object of type [string]: "\b"
-json_tokener_parse_ex(tok, "\f"        ,   4) ... OK: got object of type [string]: "\u000c"
+json_tokener_parse_ex(tok, "\f"        ,   4) ... OK: got object of type [string]: "\f"
 json_tokener_parse_ex(tok, "\n"        ,   4) ... OK: got object of type [string]: "\n"
 json_tokener_parse_ex(tok, "\r"        ,   4) ... OK: got object of type [string]: "\r"
 json_tokener_parse_ex(tok, "\t"        ,   4) ... OK: got object of type [string]: "\t"


### PR DESCRIPTION
json_object_object_add() now indicates success or failure via its return value. The previous behaviour, namely to exit the program on failure, is cumbersome in large-scale applications.

Note that the change of return value from void to int may break the ABI so that programs using json-c may have to be rebuilt.

Unrelated to this change, I found I had to adjust the expected output of test_parse for a successful build.