### PR TITLE
json_object_object_length

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -390,6 +390,11 @@ void json_object_object_add(struct json_object* jso, const char *key,
 	existing_entry->v = val;
 }
 
+int json_object_object_length(struct json_object *jso)
+{
+	return lh_table_length(jso->o.c_object);
+}
+
 struct json_object* json_object_object_get(struct json_object* jso, const char *key)
 {
 	struct json_object *result = NULL;

--- a/json_object.h
+++ b/json_object.h
@@ -215,6 +215,8 @@ extern struct json_object* json_object_new_object(void);
  */
 extern struct lh_table* json_object_get_object(struct json_object *obj);
 
+extern int json_object_object_length(struct json_object* obj);
+
 /** Add an object field to a json_object of type json_type_object
  *
  * The reference count will *not* be incremented. This is to make adding

--- a/linkhash.c
+++ b/linkhash.c
@@ -227,3 +227,7 @@ int lh_table_delete(struct lh_table *t, const void *k)
 	return lh_table_delete_entry(t, e);
 }
 
+int lh_table_length(struct lh_table *t)
+{
+	return t->count;
+}

--- a/linkhash.h
+++ b/linkhash.h
@@ -280,6 +280,7 @@ extern int lh_table_delete_entry(struct lh_table *t, struct lh_entry *e);
  */
 extern int lh_table_delete(struct lh_table *t, const void *k);
 
+extern int lh_table_length(struct lh_table *t);
 
 void lh_abort(const char *msg, ...);
 void lh_table_resize(struct lh_table *t, int new_size);


### PR DESCRIPTION
This adds a simple function, `json_object_object_length`, which returns the length of an object just as `json_object_array_length` returns the length of an array.
