### PR TITLE
rename AM_CONFIG_HEADER to AC_CONFIG_HEADER

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -20,8 +20,8 @@ AM_CONDITIONAL(ENABLE_OLDNAME_COMPAT, [test "x${enable_oldname_compat}" != "xno"
 # Checks for libraries.
 
 # Checks for header files.
-AM_CONFIG_HEADER(config.h)
-AM_CONFIG_HEADER(json_config.h)
+AC_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADER(json_config.h)
 AC_HEADER_STDC
 AC_CHECK_HEADERS(fcntl.h limits.h strings.h syslog.h unistd.h [sys/cdefs.h] [sys/param.h] stdarg.h locale.h)
 AC_CHECK_HEADER(inttypes.h,[AC_DEFINE([JSON_C_HAVE_INTTYPES_H],[1],[Public define for json_inttypes.h])])


### PR DESCRIPTION
the former has been deprecated and does not work on newer autoconf
versions.
