### PR TITLE
Fix Broken Build, Check ADVANCE_CHAR

### DIFF
--- a/json_tokener.c
+++ b/json_tokener.c
@@ -507,9 +507,13 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
                       (str[1] == '\\') &&
                       (str[2] == 'u'))
                   {
-	            ADVANCE_CHAR(str, tok);
-	            ADVANCE_CHAR(str, tok);
-
+                /* Advance through the 16 bit surrogate, and move on to the
+                 * next sequence. The next step is to process the following
+                 * characters.
+                 */
+	            if( !ADVANCE_CHAR(str, tok) || !ADVANCE_CHAR(str, tok) ) {
+                    printbuf_memappend_fast(tok->pb, (char*)utf8_replacement_char, 3);
+                }
                     /* Advance to the first char of the next sequence and
                      * continue processing with the next sequence.
                      */


### PR DESCRIPTION
Current build (using gcc (GCC) 4.7.2 20121109 (Red Hat 4.7.2-8)) breaks because of the lack of use of the return of two ADVANCE_CHAR macros. This patch will check those return values, and act accordingly if the return indicates failure. Also is the renaming of the POP_CHAR macro to PEEK_CHAR, which better represents the behavior of the macro, as was expressed in the documentation.
