### PR TITLE
one definition of json_object_object_foreach only works on c99 and later

### DIFF
--- a/json_object.h
+++ b/json_object.h
@@ -309,7 +309,7 @@ extern void json_object_object_del(struct json_object* obj, const char *key);
  * @param val the local name for the json_object* object variable defined in
  *            the body
  */
-#if defined(__GNUC__) && !defined(__STRICT_ANSI__)
+#if defined(__GNUC__) && !defined(__STRICT_ANSI__) && __STDC_VERSION__ >= 199901L
 
 # define json_object_object_foreach(obj,key,val) \
 	char *key; \
@@ -337,7 +337,7 @@ extern void json_object_object_del(struct json_object* obj, const char *key);
 			entry ## key) : 0); \
 		entry ## key = entry_next ## key)
 
-#endif /* defined(__GNUC__) && !defined(__STRICT_ANSI__) */
+#endif /* defined(__GNUC__) && !defined(__STRICT_ANSI__) && __STDC_VERSION__ >= 199901L */
 
 /** Iterate through all keys and values of an object (ANSI C Safe)
  * @param obj the json_object instance


### PR DESCRIPTION
On GCC, I had an error in my code which tries to use `json_object_object_foreach`:

```
 error: 'for' loop initial declarations are only allowed in C99 mode
 note: use option -std=c99 or -std=gnu99 to compile your code
```

I don't specify an standard during compilation, so it uses `-std=gnu89` (and I get the same error when I specify it explicitly). Enforcing `-std=c89` (or via `-ansi`) doesn't work either (for a bunch of reasons, like single-line `//` comments all over the place).

Everything works if I specify C99, but it seems like fixing the `json_object_object_foreach` definition would be best.
