### PR TITLE
fixing problem that isinf(-Inf) can be 1 or -1

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -575,10 +575,11 @@ static int json_object_double_to_json_string(struct json_object* jso,
      how to handle these cases as strings */
   if(isnan(jso->o.c_double))
     size = snprintf(buf, 128, "NaN");
-  else if(isinf(jso->o.c_double) == 1)
-    size = snprintf(buf, 128, "Infinity");
-  else if(isinf(jso->o.c_double) == -1)
-    size = snprintf(buf, 128, "-Infinity");
+  else if(isinf(jso->o.c_double))
+    if(jso->o.c_double > 0)
+      size = snprintf(buf, 128, "Infinity");
+    else
+      size = snprintf(buf, 128, "-Infinity");
   else
     size = snprintf(buf, 128, "%f", jso->o.c_double);
 


### PR DESCRIPTION
isinf(x) returns non-zero value if and only if x has an infinite value.  In some implementations isinf(Inf) == -isinf(-Inf) but not always.  This fix takes care of encoding Inf and -Inf correctly independent of the specific implementation of isinf.
