### PR TITLE
Fix potential out-of-bounds read in json_tokener_error_desc

### DIFF
--- a/json_tokener.c
+++ b/json_tokener.c
@@ -74,7 +74,7 @@ const char* json_tokener_errors[] = {
 const char *json_tokener_error_desc(enum json_tokener_error jerr)
 {
 	int jerr_int = (int)jerr;
-	if (jerr_int < 0 || jerr_int > (int)sizeof(json_tokener_errors))
+	if (jerr_int < 0 || jerr_int > (int)(sizeof(json_tokener_errors) / sizeof(json_tokener_errors[0])))
 		return "Unknown error, invalid json_tokener_error value passed to json_tokener_error_desc()";
 	return json_tokener_errors[jerr];
 }


### PR DESCRIPTION
Found by Coverity. The number of elements of an array 'ar' is found by
sizeof(ar)/sizeof(ar[0]) and not sizeof(ar)

76const char *json_tokener_error_desc(enum json_tokener_error jerr)
 77{
 78        int jerr_int = (int)jerr;
1. Condition "jerr_int < 0", taking false branch
2. Condition "jerr_int > 112 /\* (int)sizeof (gdal_json_tokener_errors) */", taking false branch
   79        if (jerr_int < 0 || jerr_int > (int)sizeof(json_tokener_errors))
   80                return "Unknown error, invalid json_tokener_error value passed to json_tokener_error_desc()";

CID 1076806 (#1 of 1): Out-of-bounds read (OVERRUN)3. overrun-local: Overrunning array "gdal_json_tokener_errors" of 14 8-byte elements at element index 112 (byte offset 896) using index "jerr" (which evaluates to 112).
 81        return json_tokener_errors[jerr];
 82}
