### PR TITLE
Add a check for the -Bsymbolic-functions linker flag

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,10 +36,10 @@ libjson_cinclude_HEADERS = \
 #libjsonx_include_HEADERS = \
 #	json_config.h
 
-libjson_c_la_LDFLAGS = -version-info 2:0:0 -no-undefined
+libjson_c_la_LDFLAGS = -version-info 2:0:0 -no-undefined @JSON_BSYMBOLIC_LDFLAGS@
 
 if ENABLE_OLDNAME_COMPAT
-libjson_la_LDFLAGS = -version-info 1:0:1 -no-undefined -ljson-c
+libjson_la_LDFLAGS = -version-info 1:0:1 -no-undefined -ljson-c @JSON_BSYMBOLIC_LDFLAGS@
 
 # Temporary libjson library.  This will be removed after one release.
 libjson_la_LIBADD = -ljson-c

--- a/configure.in
+++ b/configure.in
@@ -57,6 +57,32 @@ AC_LANG_POP([C])
 
 AM_PROG_LIBTOOL
 
+# Check for the -Bsymbolic-functions linker flag
+AC_ARG_ENABLE([Bsymbolic],
+              [AS_HELP_STRING([--disable-Bsymbolic], [Avoid linking with -Bsymbolic-function])],
+              [],
+              [enable_Bsymbolic=check])
+
+AS_IF([test "x$enable_Bsymbolic" = "xcheck"],
+      [
+        saved_LDFLAGS="${LDFLAGS}"
+        AC_MSG_CHECKING([for -Bsymbolic-functions linker flag])
+        LDFLAGS=-Wl,-Bsymbolic-functions
+        AC_TRY_LINK([], [int main (void) { return 0; }],
+                    [
+                      AC_MSG_RESULT([yes])
+                      enable_Bsymbolic=yes
+                    ],
+                    [
+                      AC_MSG_RESULT([no])
+                      enable_Bsymbolic=no
+                    ])
+        LDFLAGS="${saved_LDFLAGS}"
+      ])
+
+AS_IF([test "x$enable_Bsymbolic" = "xyes"], [JSON_BSYMBOLIC_LDFLAGS=-Wl[,]-Bsymbolic-functions])
+AC_SUBST(JSON_BSYMBOLIC_LDFLAGS)
+
 AC_CONFIG_FILES([
 Makefile
 json.pc


### PR DESCRIPTION
The -Bsymbolic-functions linker flag reduces the amount of PLT jumps in
a shared object, and has a side effect of preventing symbol collisions
in libraries and applications linking against two different shared
objects exposing the same symbol.

While the former is (generally) a performance win, the latter is less
rare than expected. For instance, PulseAudio started linking against
json-c a while ago; now, every project linking against PulseAudio is
leaking json-c symbols. In the GNOME platform, this means that projects
linking against PulseAudio cannot be safely linked against other
libraries depending on the GLib-based JSON parsing libraries JSON-GLib,
because of a symbol conflict. Nominally, this conflict would not be an
issue: libraries and applications do not need to depend on two different
JSON parsing libraries; the symbol leakage, though, ends up causing
either segmentation faults, or weird errors. For further reference,
please see: https://bugzilla.gnome.org/show_bug.cgi?id=703734

JSON-GLib already switched to using -Bsymbolic-functions, but it would
be safe if json-c did the same, wherever the linker flag is available.
