### PR TITLE
After a successful "make install", subsequent "make install" runs fail trying to rmdir a symlink

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -71,7 +71,7 @@ install-data-hook:
 	if test -d "$(DESTDIR)@includedir@/json" ; then \
 		(cd "$(DESTDIR)@includedir@/json" && \
 		rm -f $(libjson_cinclude_HEADERS)) ; \
-		rmdir "$(DESTDIR)@includedir@/json" ; \
+		test -L "$(DESTDIR)@includedir@/json" || rmdir "$(DESTDIR)@includedir@/json" ; \
 	fi
 	test \! -e "$(DESTDIR)@includedir@/json" || rm "$(DESTDIR)@includedir@/json"
 	$(LN_S) json-c "$(DESTDIR)@includedir@/json"


### PR DESCRIPTION
This PR fixes this issue:

rmdir: failed to remove `/home/jmaurice/Development/installdir/json': Not a directory
make[3]: *** [install-data-hook] Error 1
make[3]: Leaving directory`/home/jmaurice/Development/json-c'
make[2]: **\* [install-data-am] Error 2
make[2]: Leaving directory `/home/jmaurice/Development/json-c'
make[1]: *** [install-am] Error 2
make[1]: Leaving directory`/home/jmaurice/Development/json-c'
make: **\* [install-recursive] Error 1
