### PR TITLE
Handle % character properly

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -114,6 +114,7 @@ static int json_escape_str(struct printbuf *pb, char *str, int len)
 		case '"':
 		case '\\':
 		case '/':
+		case '%':
 			if(pos - start_offset > 0)
 				printbuf_memappend(pb, str + start_offset, pos - start_offset);
 
@@ -125,6 +126,7 @@ static int json_escape_str(struct printbuf *pb, char *str, int len)
 			else if(c == '"') printbuf_memappend(pb, "\\\"", 2);
 			else if(c == '\\') printbuf_memappend(pb, "\\\\", 2);
 			else if(c == '/') printbuf_memappend(pb, "\\/", 2);
+			else if(c == '%') printbuf_memappend(pb, "%%", 2);
 
 			start_offset = ++pos;
 			break;


### PR DESCRIPTION
For *printf kind of functions through which the string seems to go
somewhere in the depths of json-c '%' needs to be esacped to %%.