### PR TITLE
SONAME bump

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,7 @@ libjson_cinclude_HEADERS = \
 #libjsonx_include_HEADERS = \
 #	json_config.h
 
-libjson_c_la_LDFLAGS = -version-info 2:0:0 -no-undefined @JSON_BSYMBOLIC_LDFLAGS@
+libjson_c_la_LDFLAGS = -version-info 3:0:0 -no-undefined @JSON_BSYMBOLIC_LDFLAGS@
 
 libjson_c_la_SOURCES = \
 	arraylist.c \


### PR DESCRIPTION
The last json_tokener_errors change affects the binary package, we need a bump to solve the issue.

See [this bug of postgis.](https://bugzilla.redhat.com/show_bug.cgi?id=1123785)