### PR TITLE
Fix build using MinGW.

### DIFF
--- a/random_seed.c
+++ b/random_seed.c
@@ -181,7 +181,10 @@ static int get_dev_random_seed()
 #define HAVE_CRYPTGENRANDOM 1
 
 #include <windows.h>
+#include <wincrypt.h>
+#ifndef __GNUC__
 #pragma comment(lib, "advapi32.lib")
+#endif
 
 static int get_cryptgenrandom_seed()
 {


### PR DESCRIPTION
I tried to build json-c using a MinGW cross compiler, but it fails:

```
.../random_seed.c:184:0: error: ignoring #pragma comment  [-Werror=unknown-pragmas]
.../random_seed.c: In function 'get_cryptgenrandom_seed':
.../random_seed.c:190:5: error: unknown type name 'HCRYPTPROV'
.../random_seed.c:193:5: error: implicit declaration of function 'CryptAcquireContextW' [-Werror=implicit-function-declaration]
.../random_seed.c:193:49: error: 'PROV_RSA_FULL' undeclared (first use in this function)
.../random_seed.c:193:49: note: each undeclared identifier is reported only once for each function it appears in
.../random_seed.c:193:64: error: 'CRYPT_VERIFYCONTEXT' undeclared (first use in this function)
.../random_seed.c:193:86: error: 'CRYPT_SILENT' undeclared (first use in this function)
.../random_seed.c:198:5: error: implicit declaration of function 'CryptGenRandom' [-Werror=implicit-function-declaration]
.../random_seed.c:203:5: error: implicit declaration of function 'CryptReleaseContext' [-Werror=implicit-function-declaration]
```

There are two problems here -- a missing header, and an unsupported pragma -- and this patch fixes both.

The library now appears to work fine, in my use-case, although I'm not sure if that exercises this specific code.
