### PR TITLE
improve doc for json_object_to_json_string()

### DIFF
--- a/json_object.h
+++ b/json_object.h
@@ -161,12 +161,17 @@ extern enum json_type json_object_get_type(struct json_object *obj);
 
 /** Stringify object to json format.
  * Equivalent to json_object_to_json_string_ext(obj, JSON_C_TO_STRING_SPACED)
+ * The pointer you get is an internal of your json object. You don't
+ * have to free it, later use of json_object_put() should be sufficient.
+ * If you can not ensure there's no concurrent access to *obj use
+ * strdup().
  * @param obj the json_object instance
  * @returns a string in JSON format
  */
 extern const char* json_object_to_json_string(struct json_object *obj);
 
 /** Stringify object to json format
+ * @see json_object_to_json_string() for details on how to free string.
  * @param obj the json_object instance
  * @param flags formatting options, see JSON_C_TO_STRING_PRETTY and other constants
  * @returns a string in JSON format


### PR DESCRIPTION
The function returns a pointer, after all converting and stuff, it's this in the end:

``` C
return jso->_pb->buf;
```

This is an internal buffer handled by the json-c library itself. I suppose the size is reallocated on purpose. Doc update clarifies, the user should not free this and use strdup() in concurrent environments. I hope I understood this correctly.
