### PR TITLE
json_util: add directory check for POSIX distros

### DIFF
--- a/json_util.c
+++ b/json_util.c
@@ -71,6 +71,20 @@ struct json_object* json_object_from_file(const char *filename)
   char buf[JSON_FILE_BUF_SIZE];
   int fd, ret;
 
+#ifdef HAVE_SYS_STAT_H
+  struct stat st;
+
+  if (stat(filename, &st) < 0) {
+    MC_ERROR("json_object_from_file: could not stat file %s: %s\n",
+	     filename, strerror(errno));
+    return NULL;
+  }
+  if ((st.st_mode & S_IFMT) == S_IFDIR) {
+    MC_ERROR("json_object_from_file: path is a directory %s: %s\n",
+	     filename, strerror(errno));
+  }
+#endif
+
   if((fd = open(filename, O_RDONLY)) < 0) {
     MC_ERROR("json_object_from_file: error opening file %s: %s\n",
 	     filename, strerror(errno));


### PR DESCRIPTION
On a Linux based target (OpenWRT to be more explicit), a directory path
to json_object_from_file() returns a non-NULL object.

On WIN32 the docs say:
  http://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx

EACCES
    Tried to open a read-only file for writing, file's sharing mode does
    not allow the specified operations, or the given path is a directory.

On Linux/Unix:
  http://linux.die.net/man/2/open

EISDIR
    pathname refers to a directory and the access requested involved
    writing (that is, O_WRONLY or O_RDWR is set).

The quickest/easiest fix would be to change O_RDONLY to O_RDWR.

I feel it's safer to explicitly check on POSIX targets if the file
is a directory.

I would be fine with whatever approach, as long as it is reviewed
by the creator/maintainer.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>