### PR TITLE
Tightening the number parsing algorithm

### DIFF
--- a/tests/test_parse.c
+++ b/tests/test_parse.c
@@ -91,6 +91,23 @@ static void test_basic_parse()
 	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
 	json_object_put(new_obj);
 
+	new_obj = json_tokener_parse("12.3.4"); /* non-sensical, returns null */
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
+
+	/* was returning (int)2015 before patch, should return null */
+	new_obj = json_tokener_parse("2015-01-15");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
+
+	new_obj = json_tokener_parse("{\"FoO\"  :   -12.3E512}");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
+
+	new_obj = json_tokener_parse("{\"FoO\"  :   -12.3E51.2}"); /* non-sensical, returns null */
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
+
 	new_obj = json_tokener_parse("[\"\\n\"]");
 	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
 	json_object_put(new_obj);
@@ -194,6 +211,9 @@ struct incremental_step {
 	/* To stop parsing a number we need to reach a non-digit, e.g. a \0 */
 	{ "1",                 1, 1, json_tokener_continue, 0 },
 	{ "2",                 2, 1, json_tokener_success, 0 },
+
+	/* Some bad formatting. Check we get the correct error status */
+	{ "2015-01-15",       10, 4, json_tokener_error_parse_number, 1 },
 
 	/* Strings have a well defined end point, so we can stop at the quote */
 	{ "\"blue\"",         -1, -1, json_tokener_success, 0 },

--- a/tests/test_parse.expected
+++ b/tests/test_parse.expected
@@ -14,6 +14,10 @@ new_obj.to_string()=-Infinity
 new_obj.to_string()=true
 new_obj.to_string()=12
 new_obj.to_string()=12.3
+new_obj.to_string()=null
+new_obj.to_string()=null
+new_obj.to_string()={ "FoO": -12.3E512 }
+new_obj.to_string()=null
 new_obj.to_string()=[ "\n" ]
 new_obj.to_string()=[ "\nabc\n" ]
 new_obj.to_string()=[ null ]
@@ -48,6 +52,7 @@ json_tokener_parse_ex(tok, {"x": 123 }"X",  14) ... OK: got object of type [obje
 json_tokener_parse_ex(tok, "Y"         ,   3) ... OK: got object of type [string]: "Y"
 json_tokener_parse_ex(tok, 1           ,   1) ... OK: got correct error: continue
 json_tokener_parse_ex(tok, 2           ,   2) ... OK: got object of type [int]: 12
+json_tokener_parse_ex(tok, 2015-01-15  ,  10) ... OK: got correct error: number expected
 json_tokener_parse_ex(tok, "blue"      ,   6) ... OK: got object of type [string]: "blue"
 json_tokener_parse_ex(tok, "\""        ,   4) ... OK: got object of type [string]: "\""
 json_tokener_parse_ex(tok, "\\"        ,   4) ... OK: got object of type [string]: "\\"
@@ -61,5 +66,5 @@ json_tokener_parse_ex(tok, [1,2,3,]    ,   8) ... OK: got object of type [array]
 json_tokener_parse_ex(tok, [1,2,,3,]   ,   9) ... OK: got correct error: unexpected character
 json_tokener_parse_ex(tok, [1,2,3,]    ,   8) ... OK: got correct error: unexpected character
 json_tokener_parse_ex(tok, {"a":1,}    ,   8) ... OK: got correct error: unexpected character
-End Incremental Tests OK=29 ERROR=0
+End Incremental Tests OK=30 ERROR=0
 ==================================


### PR DESCRIPTION
Some badly formated "numbers" could get partly parsed, resulting in truncated results instead of raising an error.

Examples :
 '1.2.3'      -> (double)1.2
 '2015-01-15' -> (int)2015

Here is a first fix. It is not perfect (example: input can still end with a 'E', which is forbidden by http://json.org doc) but should avoid most non-sensically formated input.
The goal of this patch is to get submitted into Debian bugtracking system and hopefully integrated before the next release. Could you review it ?

A few tests added.

PS: If you are interested, I could continue to make it more strict for cases like '7f020e68a7' or '0x12345'. Currently, json_tokener_parse_ex() tries to return something although they are clear cases of invalid input. A number can only be followed by ',', '}' or ']' (and eventually spaces) so we probably can transform the three if-then of this patch into a single switch-cases in json_tokener_state_number.
