### PR TITLE
Fix compiler warnings

### DIFF
--- a/json_object.h
+++ b/json_object.h
@@ -339,8 +339,8 @@ extern void json_object_object_del(struct json_object* obj, const char *key);
 #if defined(__GNUC__) && !defined(__STRICT_ANSI__) && __STDC_VERSION__ >= 199901L
 
 # define json_object_object_foreach(obj,key,val) \
-	char *key; \
-	struct json_object *val __attribute__((__unused__)); \
+	char *key = NULL; \
+	struct json_object *val = NULL; \
 	for(struct lh_entry *entry ## key = json_object_get_object(obj)->head, *entry_next ## key = NULL; \
 		({ if(entry ## key) { \
 			key = (char*)entry ## key->k; \


### PR DESCRIPTION
The json_object_object_foreach macro has a couple of compiler warnings when compiled with the most pedantic of warning flags set.  This pull requests fixes those warnings.