### PR TITLE
Added array_list_del_idx and json_object_array_del_idx

### DIFF
--- a/arraylist.c
+++ b/arraylist.c
@@ -106,3 +106,18 @@ array_list_length(struct array_list *arr)
 {
   return arr->length;
 }
+
+int
+array_list_del_idx( struct array_list *arr, int idx, int count )
+{
+	int i, stop;
+
+	stop = idx + count;
+	if ( idx >= arr->length || stop > arr->length ) return -1;
+	for ( i = idx; i < stop; ++i ) {
+		if ( arr->array[i] ) arr->free_fn( arr->array[i] );
+	}
+	memmove( arr->array + idx, arr->array + stop, (arr->length - stop) * sizeof(void*) );
+	arr->length -= count;
+	return 0;
+}

--- a/arraylist.h
+++ b/arraylist.h
@@ -53,6 +53,8 @@ extern void* array_list_bsearch(const void **key,
 		struct array_list *arr,
 		int (*sort_fn)(const void *, const void *));
 
+extern int 
+array_list_del_idx(struct array_list *arr, int i, int count);
 
 #ifdef __cplusplus
 }

--- a/json_object.c
+++ b/json_object.c
@@ -926,3 +926,7 @@ struct json_object* json_object_array_get_idx(struct json_object *jso,
 	return (struct json_object*)array_list_get_idx(jso->o.c_array, idx);
 }
 
+int json_object_array_del_idx(struct json_object *jso, int idx, int count)
+{
+	return array_list_del_idx(jso->o.c_array, idx, count);
+}

--- a/json_object.h
+++ b/json_object.h
@@ -464,6 +464,19 @@ extern int json_object_array_put_idx(struct json_object *obj, int idx,
 extern struct json_object* json_object_array_get_idx(struct json_object *obj,
 						     int idx);
 
+/** Delete an elements from a specified index in an array (a json_object of type json_type_array)
+ *
+ * The reference count will be decremented for each of the deleted objects.  If there
+ * are no more owners of an element that is being deleted, then the value is 
+ * freed.  Otherwise, the reference to the value will remain in memory.
+ *
+ * @param obj the json_object instance
+ * @param idx the index to start deleting elements at
+ * @param count the number of elements to delete
+ * @returns 0 if the elements were successfully deleted
+ */
+extern int json_object_array_del_idx(struct json_object *obj, int idx, int count);
+
 /* json_bool type methods */
 
 /** Create a new empty json_object of type json_type_boolean


### PR DESCRIPTION
array_list_del_idx lets you delete a number of elements from an array list starting at a specified index. json_object_array_del_idx uses array_list_del_idx to do the same thing for json object arrays.