### PR TITLE
Link against libm when needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,10 @@ AC_CHECK_DECLS([isinf], [], [], [[#include <math.h>]])
 AC_CHECK_DECLS([_isnan], [], [], [[#include <float.h>]])
 AC_CHECK_DECLS([_finite], [], [], [[#include <float.h>]])
 
+if test "$ac_cv_have_decl_isnan" = "yes" ; then
+   AC_TRY_LINK([#include <math.h>], [float f = 0.0; return isnan(f)], [], [LIBS="$LIBS -lm"])
+fi
+
 #check if .section.gnu.warning accepts long strings (for __warn_references)
 AC_LANG_PUSH([C])
 

--- a/json-c.pc.in
+++ b/json-c.pc.in
@@ -6,6 +6,7 @@ includedir=@includedir@
 Name: json-c
 Description: JSON implementation in C
 Version: @VERSION@
-Requires: 
+Requires:
+Libs.private: @LIBS@
 Libs:  -L${libdir} -ljson-c
 Cflags: -I${includedir}/json-c


### PR DESCRIPTION
In certain C libraries (e.g uClibc), isnan() and related functions are
implemented in libm, so json-c needs to link against it. This commit
therefore adds an AC_TRY_LINK() test to check whether a program
calling isnan() can be properly linked with no special flags. If not,
we assume linking against libm is needed.

The json-c.pc.in file is also adjusted so that in the case of static
linking against json-c, -lm is also used.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>