### PR TITLE
Use only GCC-specific flags when compiling with GCC

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,3 @@
-include Makefile.am.inc
-
 EXTRA_DIST = README.html README-WIN32.html config.h.win32 doc json-c.vcproj
 SUBDIRS = . tests
 

--- a/Makefile.am.inc
+++ b/Makefile.am.inc
@@ -1,2 +1,0 @@
-AM_CFLAGS = -Wall -Werror -Wno-error=deprecated-declarations -Wextra -Wwrite-strings -Wno-unused-parameter -std=gnu99 -D_GNU_SOURCE -D_REENTRANT
-

--- a/config.h.in
+++ b/config.h.in
@@ -130,12 +130,8 @@
 /* Public define for json_inttypes.h */
 #undef JSON_C_HAVE_INTTYPES_H
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #undef LT_OBJDIR
-
-/* Define to 1 if your C compiler doesn't accept -c and -o together. */
-#undef NO_MINUS_C_MINUS_O
 
 /* Name of package */
 #undef PACKAGE

--- a/configure.ac
+++ b/configure.ac
@@ -24,21 +24,43 @@ fi
 # enable silent build by default
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes]]))
 
+# Checks for typedefs, structures, and compiler characteristics.
+AC_PROG_CC
+AM_PROG_CC_C_O
+
+dnl Try to detect/use GNU features
+CFLAGS="$CFLAGS -D_GNU_SOURCE"
+
+dnl which flags does the compiler support?
+if test "x$GCC" = "xyes"; then
+  for flag in -Wall -Wno-error=deprecated-declarations -Wextra -Wwrite-strings -Wno-unused-parameter -std=gnu99 -Werror; do
+    oCFLAGS="$CFLAGS"
+    CFLAGS="$CFLAGS $flag"
+    cachename=rd_cv_gcc_flag_`echo $flag|sed 's/[[^A-Za-z]]/_/g'`
+    AC_CACHE_CHECK([if gcc likes the $flag flag], $cachename,
+       [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[return 0 ]])],[eval $cachename=yes],[eval $cachename=no])])
+    if eval test \$$cachename = no; then
+         CFLAGS="$oCFLAGS"
+    fi
+  done
+fi
+
+dnl We need the definition, probably detect by testing the required function
+CFLAGS="$CFLAGS -D_REENTRANT"
+
+AC_C_CONST
+AC_TYPE_SIZE_T
+
 # Checks for programs.
 
 # Checks for libraries.
 
 # Checks for header files.
-AM_PROG_CC_C_O
 AC_CONFIG_HEADER(config.h)
 AC_CONFIG_HEADER(json_config.h)
 AC_HEADER_STDC
 AC_CHECK_HEADERS(fcntl.h limits.h strings.h syslog.h unistd.h [sys/cdefs.h] [sys/param.h] stdarg.h locale.h endian.h)
 AC_CHECK_HEADER(inttypes.h,[AC_DEFINE([JSON_C_HAVE_INTTYPES_H],[1],[Public define for json_inttypes.h])])
-
-# Checks for typedefs, structures, and compiler characteristics.
-AC_C_CONST
-AC_TYPE_SIZE_T
 
 # Checks for library functions.
 AC_FUNC_VPRINTF

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,3 @@
-
-include ../Makefile.am.inc
 LDADD= $(LIBJSON_LA)
 
 LIBJSON_LA=$(top_builddir)/libjson-c.la

--- a/tests/test-defs.sh
+++ b/tests/test-defs.sh
@@ -41,7 +41,7 @@ esac
 
 rm -rf "$testsubdir" > /dev/null 2>&1
 mkdir -p "$testsubdir"
-CURDIR=$(pwd)
+CURDIR=`pwd`
 cd "$testsubdir" \
    || { echo "Cannot make or change into $testsubdir"; exit 1; }
 
@@ -50,7 +50,7 @@ echo "=== Running test $progname"
 CMP="${CMP-cmp}"
 
 use_valgrind=${USE_VALGRIND-1}
-valgrind_path=$(which valgrind 2> /dev/null)
+valgrind_path=`which valgrind 2> /dev/null`
 if [ -z "${valgrind_path}" -o ! -x "${valgrind_path}" ] ; then
 	use_valgrind=0
 fi


### PR DESCRIPTION
Hi,

these are some adjustments on the autoconf-foo that enhance the compatibility with non-GCC compilers.

Best regards -- Dago