### PR TITLE
Syntax error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ else
 fi
 
 # enable silent build by default
-m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes]]))
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 # Checks for programs.
 


### PR DESCRIPTION
- ./configure fails due to bad code generation

On SLES 11.3:

```bash
92 [master] /> ./autogen.sh 
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal 
autoreconf: configure.ac: tracing
autoreconf: running: libtoolize --copy
libtoolize: putting auxiliary files in `.'.
libtoolize: copying file `./ltmain.sh'
libtoolize: Consider adding `AC_CONFIG_MACRO_DIR([m4])' to configure.ac and
libtoolize: rerunning libtoolize, to keep the correct libtool macros in-tree.
libtoolize: Consider adding `-I m4' to ACLOCAL_AMFLAGS in Makefile.am.
autoreconf: running: /usr/bin/autoconf
autoreconf: running: /usr/bin/autoheader
autoreconf: running: automake --add-missing --copy --no-force
configure.ac:32: installing `./compile'
configure.ac:78: installing `./config.guess'
configure.ac:78: installing `./config.sub'
configure.ac:6: installing `./install-sh'
configure.ac:6: installing `./missing'
tests/Makefile.am: installing `./depcomp'
Makefile.am: installing `./INSTALL'
autoreconf: Leaving directory `.'
93 [master] /> ./configure 
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make sets $(MAKE)... (cached) yes
RDRAND Hardware RNG Hash Seed disabled. Use --enable-rdrand to enable
./configure: line 2569: syntax error near unexpected token `)'
./configure: line 2569: `)'
```

The m4 macro is failing to generate the code correctly. Notice the stray ')' after #enable silent build by default. 
```bash
  { $as_echo "$as_me:$LINENO: result: RDRAND Hardware RNG Hash Seed disabled. Use --enable-rdrand to enable" >&5
$as_echo "RDRAND Hardware RNG Hash Seed disabled. Use --enable-rdrand to enable" >&6; }
fi

# enable silent build by default
)

# Checks for programs.
```

autoconf -> 2.63-1.160.2
automake -> 1.10.1-4.131.9.1