### PR TITLE
Override int64 to only display uint64 strings

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -509,6 +509,8 @@ static int json_object_int_to_json_string(struct json_object* jso,
 					  int level,
 					  int flags)
 {
+	if (flags & JSON_C_TO_STRING_UINT64)
+		return sprintbuf(pb, "%"PRIu64, jso->o.c_int64);
 	return sprintbuf(pb, "%"PRId64, jso->o.c_int64);
 }
 

--- a/json_object.h
+++ b/json_object.h
@@ -62,6 +62,11 @@ extern "C" {
  * A flag to drop trailing zero for float values
  */
 #define JSON_C_TO_STRING_NOZERO     (1<<2)
+/**
+ * Force integer to output unsigned
+ * Useful when dealing with very large 64 bit numbers without negatives
+ */
+#define JSON_C_TO_STRING_UINT64     (1<<4)
 
 #undef FALSE
 #define FALSE ((json_bool)0)


### PR DESCRIPTION
- Not true uint64 support, but should handle all cases properly
- Useful for when dealing with large 64 bit numbers without negatives

I've also done some initial code to implement true uint64 support but it's quite invasive (don't have all test cases passing yet either). The project I'm using json-c with doesn't not require signed numbers at all but it does deal with extremely large 64 bit numbers.

I'm not terribly worried if there is push back from this pull request.
