### PR TITLE
Make serialization format of doubles configurable

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -55,7 +55,6 @@ static struct json_object* json_object_new(enum json_type o_type);
 static json_object_to_json_string_fn json_object_object_to_json_string;
 static json_object_to_json_string_fn json_object_boolean_to_json_string;
 static json_object_to_json_string_fn json_object_int_to_json_string;
-static json_object_to_json_string_fn json_object_double_to_json_string;
 static json_object_to_json_string_fn json_object_string_to_json_string;
 static json_object_to_json_string_fn json_object_array_to_json_string;
 
@@ -644,10 +643,10 @@ int64_t json_object_get_int64(const struct json_object *jso)
 
 /* json_object_double */
 
-static int json_object_double_to_json_string(struct json_object* jso,
-					     struct printbuf *pb,
-					     int level,
-						 int flags)
+int json_object_double_to_json_string(struct json_object* jso,
+				      struct printbuf *pb,
+				      int level,
+				      int flags)
 {
   char buf[128], *p, *q;
   int size;
@@ -663,7 +662,8 @@ static int json_object_double_to_json_string(struct json_object* jso,
     else
       size = snprintf(buf, sizeof(buf), "-Infinity");
   else
-    size = snprintf(buf, sizeof(buf), "%.17g", jso->o.c_double);
+    size = snprintf(buf, sizeof(buf),
+        jso->_userdata ? (const char*) jso->_userdata : "%.17g", jso->o.c_double);
 
   p = strchr(buf, ',');
   if (p) {

--- a/json_object.h
+++ b/json_object.h
@@ -614,6 +614,9 @@ extern int64_t json_object_get_int64(const struct json_object *obj);
 /* double type methods */
 
 /** Create a new empty json_object of type json_type_double
+ *
+ * @see json_object_double_to_json_string() for how to set a custom format string.
+ *
  * @param d the double
  * @returns a json_object of type json_type_double
  */
@@ -641,6 +644,31 @@ extern struct json_object* json_object_new_double(double d);
  * @param ds the string representation of the double.  This will be copied.
  */
 extern struct json_object* json_object_new_double_s(double d, const char *ds);
+
+
+/** Serialize a json_object of type json_type_double to a string.
+ *
+ * This function isn't meant to be called directly. Instead, you can set a
+ * custom format string for the serialization of this double using the
+ * following call (where "%.17g" actually is the default):
+ *
+ * @code
+ *   jso = json_object_new_double(d);
+ *   json_object_set_serializer(jso, json_object_double_to_json_string,
+ *       "%.17g", NULL);
+ * @endcode
+ *
+ * @see printf(3) man page for format strings
+ *
+ * @param jso The json_type_double object that is serialized.
+ * @param pb The destination buffer.
+ * @param level Ignored.
+ * @param flags Ignored.
+ */
+extern int json_object_double_to_json_string(struct json_object* jso,
+					     struct printbuf *pb,
+					     int level,
+					     int flags);
 
 /** Get the double floating point value of a json_object
  *

--- a/json_object.h
+++ b/json_object.h
@@ -633,8 +633,8 @@ extern struct json_object* json_object_new_double(double d);
  * An equivalent sequence of calls is:
  * @code
  *   jso = json_object_new_double(d);
- *   json_object_set_serializer(d, json_object_userdata_to_json_string,
- *       strdup(ds), json_object_free_userdata)
+ *   json_object_set_serializer(jso, json_object_userdata_to_json_string,
+ *       strdup(ds), json_object_free_userdata);
  * @endcode
  *
  * @param d the numeric value of the double.


### PR DESCRIPTION
Using the new function `json_object_new_double_fmt(double d, char *fmt)`, one can now specify what printf-compatible format string should be used to serialize this specific double. This allows for dynamic adaptation of the precision depending on the precision of the source as well as the indended usage.

This fixes #154 and #59.