### PR TITLE
Add build scripts for CI platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_script:
 
 script:
   - make
-  - make install
 
 after_success:
   - make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: cpp
+
+compiler:
+  - gcc
+
+os:
+  - linux
+
+before_install:
+  - echo $LANG
+  - echo $LC_ALL
+
+install:
+  - sh autogen.sh
+
+before_script:
+  - ./configure
+
+script:
+  - make
+  - make install
+
+after_success:
+  - make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: cpp
 
 compiler:
   - gcc
+  - clang
 
 os:
   - linux
+  - osx
 
 before_install:
   - echo $LANG

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+version: '{branch}.{build}'
+os: Windows Server 2012 R2
+configuration:
+- Debug
+- Release
+platform: x64
+environment:
+  matrix:
+  - PlatformToolset: v140
+  - PlatformToolset: v120
+  - PlatformToolset: Windows7.1SDK
+build_script:
+- >
+  msbuild "json-c.vcxproj" /m /verbosity:normal
+  /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  /p:PlatformToolset=%PlatformToolset%
+artifacts:
+- path: Debug\*
+  name: Debug_x86
+- path: Release\*
+  name: Release_x86
+- path: x64\Debug\*
+  name: Debug_x64
+- path: x64\Release\*
+  name: Release_x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,18 +15,28 @@ build_script:
 - >
   msbuild "json-c.vcxproj" /m /verbosity:normal
   /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-  /p:PlatformToolset=%PlatformToolset%
+  /p:PlatformToolset=%PlatformToolset% /p:OutDir=lib\
+
+after_build:
+- md include\json-c
+- copy json.h include\json-c\*
+- copy debug.h include\json-c\*
+- copy linkhash.h include\json-c\*
+- copy arraylist.h include\json-c\*
+- copy json_util.h include\json-c\*
+- copy json_object.h include\json-c\*
+- copy json_tokener.h include\json-c\*
+- copy json_object_iterator.h include\json-c\*
+- copy json_c_version.h include\json-c\*
+- copy json_inttypes.h include\json-c\*
+- copy json_config.h include\json-c\*
+- copy json_object_private.h include\json-c\*
+- 7z a json-c.lib.zip lib\json-c.lib include\json-c\*.h
 
 matrix:
   allow_failures:
     - PlatformToolset: v140
 
 artifacts:
-- path: Debug\*
-  name: Debug_x86
-- path: Release\*
-  name: Release_x86
-- path: x64\Debug\*
-  name: Debug_x64
-- path: x64\Release\*
-  name: Release_x64
+- path: json-c.lib.zip
+  name: json-c.lib.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,10 +33,6 @@ after_build:
 - copy json_object_private.h include\json-c\*
 - 7z a json-c.lib.zip lib\json-c.lib include\json-c\*.h
 
-matrix:
-  allow_failures:
-    - PlatformToolset: v140
-
 artifacts:
 - path: json-c.lib.zip
   name: json-c.lib.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 version: '{branch}.{build}'
 os: Windows Server 2012 R2
+
 configuration:
 - Debug
 - Release
@@ -9,11 +10,17 @@ environment:
   - PlatformToolset: v140
   - PlatformToolset: v120
   - PlatformToolset: Windows7.1SDK
+
 build_script:
 - >
   msbuild "json-c.vcxproj" /m /verbosity:normal
   /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
   /p:PlatformToolset=%PlatformToolset%
+
+matrix:
+  allow_failures:
+    - PlatformToolset: v140
+
 artifacts:
 - path: Debug\*
   name: Debug_x86


### PR DESCRIPTION
Added build scripts for:
* Travis CI (Linux + OSX) https://travis-ci.org/Nzbuu/json-c
* Appveyor (Windows) https://ci.appveyor.com/project/Nzbuu/json-c

Windows build fails due to error fixed in PR #199.