### PR TITLE
Performance enhancements (mainly) to json_object_to_json_string()

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -169,7 +169,7 @@ static char needsEscape[256] = {
 	0, 0, 0, 0, 0, 0, 0, 0
 };
 
-static int json_escape_str(struct printbuf *pb, const char *str, int len)
+static void json_escape_str(struct printbuf *pb, const char *str, int len)
 {
 	int pos = 0, start_offset = 0;
 	unsigned char c;
@@ -177,44 +177,37 @@ static int json_escape_str(struct printbuf *pb, const char *str, int len)
 	{
 		c = str[pos];
 		if(needsEscape[c]) {
+			if(pos - start_offset > 0)
+				printbuf_memappend_no_nul(pb, str + start_offset, pos - start_offset);
 			switch(c)
 			{
-			case '\b':
-			case '\n':
-			case '\r':
-			case '\t':
-			case '\f':
-			case '"':
-			case '\\':
-			case '/':
-				if(pos - start_offset > 0)
-					printbuf_memappend_no_nul(pb, str + start_offset, pos - start_offset);
-
-				if(c == '\b') printbuf_memappend_no_nul(pb, "\\b", 2);
-				else if(c == '\n') printbuf_memappend_no_nul(pb, "\\n", 2);
-				else if(c == '\r') printbuf_memappend_no_nul(pb, "\\r", 2);
-				else if(c == '\t') printbuf_memappend_no_nul(pb, "\\t", 2);
-				else if(c == '\f') printbuf_memappend_no_nul(pb, "\\f", 2);
-				else if(c == '"') printbuf_memappend_no_nul(pb, "\\\"", 2);
-				else if(c == '\\') printbuf_memappend_no_nul(pb, "\\\\", 2);
-				else if(c == '/') printbuf_memappend_no_nul(pb, "\\/", 2);
-
-				start_offset = ++pos;
+			case '\b': printbuf_memappend_no_nul(pb, "\\b", 2);
 				break;
-			default:
-				if(pos - start_offset > 0)
-				printbuf_memappend_no_nul(pb, str + start_offset, pos - start_offset);
-				sprintbuf(pb, "\\u00%c%c",
+			case '\n': printbuf_memappend_no_nul(pb, "\\n", 2);
+				break;
+			case '\r': printbuf_memappend_no_nul(pb, "\\r", 2);
+				break;
+			case '\t': printbuf_memappend_no_nul(pb, "\\t", 2);
+				break;
+			case '\f': printbuf_memappend_no_nul(pb, "\\f", 2);
+				break;
+			case '"': printbuf_memappend_no_nul(pb, "\\\"", 2);
+				break;
+			case '\\': printbuf_memappend_no_nul(pb, "\\\\", 2);
+				break;
+			case '/': printbuf_memappend_no_nul(pb, "\\/", 2);
+				break;
+			default: sprintbuf(pb, "\\u00%c%c",
 				json_hex_chars[c >> 4],
 				json_hex_chars[c & 0xf]);
-				start_offset = ++pos;
+				break;
 			}
+			start_offset = ++pos;
 		} else
 			pos++;
 	}
 	if (pos - start_offset > 0)
 		printbuf_memappend_no_nul(pb, str + start_offset, pos - start_offset);
-	return 0;
 }
 
 

--- a/json_object.c
+++ b/json_object.c
@@ -110,7 +110,7 @@ static int json_escape_str(struct printbuf *pb, const char *str, int len)
 {
 	int pos = 0, start_offset = 0;
 	unsigned char c;
-	while (len--)
+	while (pos < len)
 	{
 		c = str[pos];
 		switch(c)

--- a/json_object.c
+++ b/json_object.c
@@ -292,8 +292,7 @@ const char* json_object_to_json_string_ext(struct json_object *jso, int flags)
 
 	printbuf_reset(jso->_pb);
 
-	if(jso->_to_json_string(jso, jso->_pb, 0, flags) < 0)
-		return NULL;
+	jso->_to_json_string(jso, jso->_pb, 0, flags);
 
 	printbuf_terminate_string(jso->_pb);
 	return jso->_pb->buf;
@@ -323,7 +322,7 @@ static void indent(struct printbuf *pb, int level, int flags)
 
 /* json_object_object */
 
-static int json_object_object_to_json_string(struct json_object* jso,
+static void json_object_object_to_json_string(struct json_object* jso,
 					     struct printbuf *pb,
 					     int level,
 						 int flags)
@@ -364,9 +363,9 @@ static int json_object_object_to_json_string(struct json_object* jso,
 		indent(pb,level,flags);
 	}
 	if (flags & JSON_C_TO_STRING_SPACED)
-		return printbuf_memappend_no_nul(pb, /*{*/ " }", 2);
+		printbuf_memappend_no_nul(pb, /*{*/ " }", 2);
 	else
-		return printbuf_memappend_no_nul(pb, /*{*/ "}", 1);
+		printbuf_memappend_no_nul(pb, /*{*/ "}", 1);
 }
 
 
@@ -499,15 +498,15 @@ void json_object_object_del(struct json_object* jso, const char *key)
 
 /* json_object_boolean */
 
-static int json_object_boolean_to_json_string(struct json_object* jso,
+static void json_object_boolean_to_json_string(struct json_object* jso,
 					      struct printbuf *pb,
 					      int level,
 						  int flags)
 {
 	if (jso->o.c_boolean)
-		return printbuf_memappend_no_nul(pb, "true", 4);
+		printbuf_memappend_no_nul(pb, "true", 4);
 	else
-		return printbuf_memappend_no_nul(pb, "false", 5);
+		printbuf_memappend_no_nul(pb, "false", 5);
 }
 
 struct json_object* json_object_new_boolean(json_bool b)
@@ -542,12 +541,12 @@ json_bool json_object_get_boolean(struct json_object *jso)
 
 /* json_object_int */
 
-static int json_object_int_to_json_string(struct json_object* jso,
+static void json_object_int_to_json_string(struct json_object* jso,
 					  struct printbuf *pb,
 					  int level,
 					  int flags)
 {
-	return sprintbuf(pb, "%" PRId64, jso->o.c_int64);
+	sprintbuf(pb, "%" PRId64, jso->o.c_int64);
 }
 
 struct json_object* json_object_new_int(int32_t i)
@@ -634,7 +633,7 @@ int64_t json_object_get_int64(struct json_object *jso)
 
 /* json_object_double */
 
-static int json_object_double_to_json_string(struct json_object* jso,
+static void json_object_double_to_json_string(struct json_object* jso,
 					     struct printbuf *pb,
 					     int level,
 						 int flags)
@@ -672,7 +671,6 @@ static int json_object_double_to_json_string(struct json_object* jso,
     size = p-buf;
   }
   printbuf_memappend_no_nul(pb, buf, size);
-  return size;
 }
 
 struct json_object* json_object_new_double(double d)
@@ -703,12 +701,11 @@ struct json_object* json_object_new_double_s(double d, const char *ds)
 	return jso;
 }
 
-int json_object_userdata_to_json_string(struct json_object *jso,
+void json_object_userdata_to_json_string(struct json_object *jso,
 	struct printbuf *pb, int level, int flags)
 {
 	int userdata_len = strlen((const char *)jso->_userdata);
 	printbuf_memappend_no_nul(pb, (const char *)jso->_userdata, userdata_len);
-	return userdata_len;
 }
 
 void json_object_free_userdata(struct json_object *jso, void *userdata)
@@ -768,7 +765,7 @@ double json_object_get_double(struct json_object *jso)
 
 /* json_object_string */
 
-static int json_object_string_to_json_string(struct json_object* jso,
+static void json_object_string_to_json_string(struct json_object* jso,
 					     struct printbuf *pb,
 					     int level,
 						 int flags)
@@ -776,7 +773,6 @@ static int json_object_string_to_json_string(struct json_object* jso,
 	printbuf_memappend_no_nul(pb, "\"", 1);
 	json_escape_str(pb, get_string_component(jso), jso->o.c_string.len);
 	printbuf_memappend_no_nul(pb, "\"", 1);
-	return 0;
 }
 
 static void json_object_string_delete(struct json_object* jso)
@@ -863,7 +859,7 @@ int json_object_get_string_len(struct json_object *jso)
 
 /* json_object_array */
 
-static int json_object_array_to_json_string(struct json_object* jso,
+static void json_object_array_to_json_string(struct json_object* jso,
                                             struct printbuf *pb,
                                             int level,
                                             int flags)
@@ -900,9 +896,9 @@ static int json_object_array_to_json_string(struct json_object* jso,
 	}
 
 	if (flags & JSON_C_TO_STRING_SPACED)
-		return printbuf_memappend_no_nul(pb, " ]", 2);
+		printbuf_memappend_no_nul(pb, " ]", 2);
 	else
-		return printbuf_memappend_no_nul(pb, "]", 1);
+		printbuf_memappend_no_nul(pb, "]", 1);
 }
 
 static void json_object_array_entry_free(void *data)

--- a/json_object.c
+++ b/json_object.c
@@ -330,42 +330,42 @@ static int json_object_object_to_json_string(struct json_object* jso,
 	int had_children = 0;
 	struct json_object_iter iter;
 
-	sprintbuf(pb, "{" /*}*/);
+	printbuf_memappend(pb, "{" /*}*/, 1);
 	if (flags & JSON_C_TO_STRING_PRETTY)
-		sprintbuf(pb, "\n");
+		printbuf_memappend(pb, "\n", 1);
 	json_object_object_foreachC(jso, iter)
 	{
 		if (had_children)
 		{
-			sprintbuf(pb, ",");
+			printbuf_memappend(pb, ",", 1);
 			if (flags & JSON_C_TO_STRING_PRETTY)
-				sprintbuf(pb, "\n");
+				printbuf_memappend(pb, "\n", 1);
 		}
 		had_children = 1;
 		if (flags & JSON_C_TO_STRING_SPACED)
-			sprintbuf(pb, " ");
+			printbuf_memappend(pb, " ", 1);
 		indent(pb, level+1, flags);
-		sprintbuf(pb, "\"");
+		printbuf_memappend(pb, "\"", 1);
 		json_escape_str(pb, iter.key, strlen(iter.key));
 		if (flags & JSON_C_TO_STRING_SPACED)
-			sprintbuf(pb, "\": ");
+			printbuf_memappend(pb, "\": ", 3);
 		else
-			sprintbuf(pb, "\":");
+			printbuf_memappend(pb, "\":", 2);
 		if(iter.val == NULL)
-			sprintbuf(pb, "null");
+			printbuf_memappend(pb, "null", 4);
 		else
 			iter.val->_to_json_string(iter.val, pb, level+1,flags);
 	}
 	if (flags & JSON_C_TO_STRING_PRETTY)
 	{
 		if (had_children)
-			sprintbuf(pb, "\n");
+			printbuf_memappend(pb, "\n",1);
 		indent(pb,level,flags);
 	}
 	if (flags & JSON_C_TO_STRING_SPACED)
-		return sprintbuf(pb, /*{*/ " }");
+		return printbuf_memappend(pb, /*{*/ " }", 2);
 	else
-		return sprintbuf(pb, /*{*/ "}");
+		return printbuf_memappend(pb, /*{*/ "}", 1);
 }
 
 
@@ -504,9 +504,9 @@ static int json_object_boolean_to_json_string(struct json_object* jso,
 						  int flags)
 {
 	if (jso->o.c_boolean)
-		return sprintbuf(pb, "true");
+		return printbuf_memappend(pb, "true", 4);
 	else
-		return sprintbuf(pb, "false");
+		return printbuf_memappend(pb, "false", 5);
 }
 
 struct json_object* json_object_new_boolean(json_bool b)
@@ -772,9 +772,9 @@ static int json_object_string_to_json_string(struct json_object* jso,
 					     int level,
 						 int flags)
 {
-	sprintbuf(pb, "\"");
+	printbuf_memappend(pb, "\"", 1);
 	json_escape_str(pb, get_string_component(jso), jso->o.c_string.len);
-	sprintbuf(pb, "\"");
+	printbuf_memappend(pb, "\"", 1);
 	return 0;
 }
 
@@ -869,39 +869,39 @@ static int json_object_array_to_json_string(struct json_object* jso,
 {
 	int had_children = 0;
 	int ii;
-	sprintbuf(pb, "[");
+	printbuf_memappend(pb, "[", 1);
 	if (flags & JSON_C_TO_STRING_PRETTY)
-		sprintbuf(pb, "\n");
+		printbuf_memappend(pb, "\n", 1);
 	for(ii=0; ii < json_object_array_length(jso); ii++)
 	{
 		struct json_object *val;
 		if (had_children)
 		{
-			sprintbuf(pb, ",");
+			printbuf_memappend(pb, ",", 1);
 			if (flags & JSON_C_TO_STRING_PRETTY)
-				sprintbuf(pb, "\n");
+				printbuf_memappend(pb, "\n", 1);
 		}
 		had_children = 1;
 		if (flags & JSON_C_TO_STRING_SPACED)
-			sprintbuf(pb, " ");
+			printbuf_memappend(pb, " ", 1);
 		indent(pb, level + 1, flags);
 		val = json_object_array_get_idx(jso, ii);
 		if(val == NULL)
-			sprintbuf(pb, "null");
+			printbuf_memappend(pb, "null", 4);
 		else
 			val->_to_json_string(val, pb, level+1, flags);
 	}
 	if (flags & JSON_C_TO_STRING_PRETTY)
 	{
 		if (had_children)
-			sprintbuf(pb, "\n");
+			printbuf_memappend(pb, "\n", 1);
 		indent(pb,level,flags);
 	}
 
 	if (flags & JSON_C_TO_STRING_SPACED)
-		return sprintbuf(pb, " ]");
+		return printbuf_memappend(pb, " ]", 2);
 	else
-		return sprintbuf(pb, "]");
+		return printbuf_memappend(pb, "]", 1);
 }
 
 static void json_object_array_entry_free(void *data)

--- a/json_object.c
+++ b/json_object.c
@@ -377,7 +377,7 @@ static void indent(struct printbuf *pb, int level, int flags)
 
 /* json_object_object */
 
-static void json_object_object_to_json_string(struct json_object* jso,
+static int json_object_object_to_json_string(struct json_object* jso,
 					     struct printbuf *pb,
 					     int level,
 						 int flags)
@@ -421,6 +421,7 @@ static void json_object_object_to_json_string(struct json_object* jso,
 		printbuf_memappend_no_nul(pb, /*{*/ " }", 2);
 	else
 		printbuf_memappend_no_nul(pb, /*{*/ "}", 1);
+	return 0; /* we need to keep compatible with the API */
 }
 
 
@@ -553,7 +554,7 @@ void json_object_object_del(struct json_object* jso, const char *key)
 
 /* json_object_boolean */
 
-static void json_object_boolean_to_json_string(struct json_object* jso,
+static int json_object_boolean_to_json_string(struct json_object* jso,
 					      struct printbuf *pb,
 					      int level,
 						  int flags)
@@ -562,6 +563,7 @@ static void json_object_boolean_to_json_string(struct json_object* jso,
 		printbuf_memappend_no_nul(pb, "true", 4);
 	else
 		printbuf_memappend_no_nul(pb, "false", 5);
+	return 0; /* we need to keep compatible with the API */
 }
 
 struct json_object* json_object_new_boolean(json_bool b)
@@ -596,12 +598,13 @@ json_bool json_object_get_boolean(struct json_object *jso)
 
 /* json_object_int */
 
-static void json_object_int_to_json_string(struct json_object* jso,
+static int json_object_int_to_json_string(struct json_object* jso,
 					  struct printbuf *pb,
 					  int level,
 					  int flags)
 {
 	sprintbuf(pb, "%" PRId64, jso->o.c_int64);
+	return 0; /* we need to keep compatible with the API */
 }
 
 struct json_object* json_object_new_int(int32_t i)
@@ -688,7 +691,7 @@ int64_t json_object_get_int64(struct json_object *jso)
 
 /* json_object_double */
 
-static void json_object_double_to_json_string(struct json_object* jso,
+static int json_object_double_to_json_string(struct json_object* jso,
 					     struct printbuf *pb,
 					     int level,
 						 int flags)
@@ -726,6 +729,7 @@ static void json_object_double_to_json_string(struct json_object* jso,
     size = p-buf;
   }
   printbuf_memappend_no_nul(pb, buf, size);
+  return 0; /* we need to keep compatible with the API */
 }
 
 struct json_object* json_object_new_double(double d)
@@ -756,11 +760,12 @@ struct json_object* json_object_new_double_s(double d, const char *ds)
 	return jso;
 }
 
-void json_object_userdata_to_json_string(struct json_object *jso,
+int json_object_userdata_to_json_string(struct json_object *jso,
 	struct printbuf *pb, int level, int flags)
 {
 	int userdata_len = strlen((const char *)jso->_userdata);
 	printbuf_memappend_no_nul(pb, (const char *)jso->_userdata, userdata_len);
+	return 0; /* we need to keep compatible with the API */
 }
 
 void json_object_free_userdata(struct json_object *jso, void *userdata)
@@ -820,7 +825,7 @@ double json_object_get_double(struct json_object *jso)
 
 /* json_object_string */
 
-static void json_object_string_to_json_string(struct json_object* jso,
+static int json_object_string_to_json_string(struct json_object* jso,
 					     struct printbuf *pb,
 					     int level,
 						 int flags)
@@ -828,6 +833,7 @@ static void json_object_string_to_json_string(struct json_object* jso,
 	printbuf_memappend_no_nul(pb, "\"", 1);
 	json_escape_str(pb, get_string_component(jso), jso->o.c_string.len);
 	printbuf_memappend_no_nul(pb, "\"", 1);
+	return 0; /* we need to keep compatible with the API */
 }
 
 static void json_object_string_delete(struct json_object* jso)
@@ -914,7 +920,7 @@ int json_object_get_string_len(struct json_object *jso)
 
 /* json_object_array */
 
-static void json_object_array_to_json_string(struct json_object* jso,
+static int json_object_array_to_json_string(struct json_object* jso,
                                             struct printbuf *pb,
                                             int level,
                                             int flags)
@@ -954,6 +960,7 @@ static void json_object_array_to_json_string(struct json_object* jso,
 		printbuf_memappend_no_nul(pb, " ]", 2);
 	else
 		printbuf_memappend_no_nul(pb, "]", 1);
+	return 0; /* we need to keep compatible with the API */
 }
 
 static void json_object_array_entry_free(void *data)

--- a/json_object.h
+++ b/json_object.h
@@ -128,7 +128,7 @@ typedef void (json_object_delete_fn)(struct json_object *jso, void *userdata);
 /**
  * Type of a custom serialization function.  See json_object_set_serializer.
  */
-typedef int (json_object_to_json_string_fn)(struct json_object *jso,
+typedef void (json_object_to_json_string_fn)(struct json_object *jso,
 						struct printbuf *pb,
 						int level,
 						int flags);

--- a/json_object.h
+++ b/json_object.h
@@ -128,7 +128,7 @@ typedef void (json_object_delete_fn)(struct json_object *jso, void *userdata);
 /**
  * Type of a custom serialization function.  See json_object_set_serializer.
  */
-typedef void (json_object_to_json_string_fn)(struct json_object *jso,
+typedef int (json_object_to_json_string_fn)(struct json_object *jso,
 						struct printbuf *pb,
 						int level,
 						int flags);

--- a/printbuf.c
+++ b/printbuf.c
@@ -28,7 +28,13 @@
 #include "debug.h"
 #include "printbuf.h"
 
+static int printbuf_initial_size = 32;
 static int printbuf_extend(struct printbuf *p, int min_size);
+
+void json_global_set_printbuf_initial_size(int size)
+{
+	printbuf_initial_size = size;
+}
 
 struct printbuf* printbuf_new(void)
 {
@@ -36,7 +42,7 @@ struct printbuf* printbuf_new(void)
 
   p = (struct printbuf*)calloc(1, sizeof(struct printbuf));
   if(!p) return NULL;
-  p->size = 32;
+  p->size = printbuf_initial_size;
   p->bpos = 0;
   if(!(p->buf = (char*)malloc(p->size))) {
     free(p);

--- a/printbuf.c
+++ b/printbuf.c
@@ -92,6 +92,30 @@ int printbuf_memappend(struct printbuf *p, const char *buf, int size)
   return size;
 }
 
+/* same as printbuf_memappend(), but contains some performance enhancements */
+int printbuf_memappend_no_nul(struct printbuf *p, const char *buf, const int size)
+{
+  if (p->size <= p->bpos + size) {
+    if (printbuf_extend(p, p->bpos + size + 1) < 0)
+      return -1;
+  }
+  if(size > 1)
+    memcpy(p->buf + p->bpos, buf, size);
+  else
+    p->buf[p->bpos]= *buf;
+  p->bpos += size;
+  return 1;
+}
+
+void printbuf_terminate_string(struct printbuf *const p)
+{
+  if (p->size <= p->bpos + 1) {
+    if (printbuf_extend(p, p->bpos + 1) < 0)
+      --p->bpos; /* overwrite last byte, best we can do */
+  }
+  p->buf[p->bpos]= '\0';
+}
+
 int printbuf_memset(struct printbuf *pb, int offset, int charvalue, int len)
 {
 	int size_needed;

--- a/printbuf.c
+++ b/printbuf.c
@@ -83,7 +83,10 @@ int printbuf_memappend(struct printbuf *p, const char *buf, int size)
     if (printbuf_extend(p, p->bpos + size + 1) < 0)
       return -1;
   }
-  memcpy(p->buf + p->bpos, buf, size);
+  if(size > 1)
+    memcpy(p->buf + p->bpos, buf, size);
+  else
+    p->buf[p->bpos]= *buf;
   p->bpos += size;
   p->buf[p->bpos]= '\0';
   return size;

--- a/printbuf.c
+++ b/printbuf.c
@@ -93,18 +93,18 @@ int printbuf_memappend(struct printbuf *p, const char *buf, int size)
 }
 
 /* same as printbuf_memappend(), but contains some performance enhancements */
-int printbuf_memappend_no_nul(struct printbuf *p, const char *buf, const int size)
+void printbuf_memappend_no_nul(struct printbuf *p, const char *buf, const int size)
 {
   if (p->size <= p->bpos + size) {
-    if (printbuf_extend(p, p->bpos + size + 1) < 0)
-      return -1;
+    if (printbuf_extend(p, p->bpos + size) < 0)
+       /* ignore new data, best we can do */
+       return;
   }
   if(size > 1)
     memcpy(p->buf + p->bpos, buf, size);
   else
     p->buf[p->bpos]= *buf;
   p->bpos += size;
-  return 1;
 }
 
 void printbuf_terminate_string(struct printbuf *const p)

--- a/printbuf.h
+++ b/printbuf.h
@@ -48,6 +48,17 @@ do {                                                         \
   } else {  printbuf_memappend(p, (bufptr), bufsize); }      \
 } while (0)
 
+/* The following functions provide a printbuf interface where the
+ * string terminator '\0' is not always written. This is faster, but
+ * the string cannot be used with standard functions while being
+ * constructed. To do so, printbuf_terminate_string() must be
+ * called first.
+ */
+extern int
+printbuf_memappend_no_nul(struct printbuf *p, const char *buf, int size);
+extern void
+printbuf_terminate_string(struct printbuf *const p);
+
 #define printbuf_length(p) ((p)->bpos)
 
 /**

--- a/printbuf.h
+++ b/printbuf.h
@@ -81,6 +81,27 @@ printbuf_reset(struct printbuf *p);
 extern void
 printbuf_free(struct printbuf *p);
 
+/**
+ * Set initial size allocation for memory when creating strings,
+ * as is done for example in json_object_to_json_string(). The
+ * default size is 32, which is very conservative. If an app
+ * knows it typically deals with larger strings, performance
+ * can be improved by setting the initial size to a different
+ * number, e.g. 1k. Note that this also means that memory
+ * consumption can increase. How far entriely depens on the
+ * application and its use of json-c.
+ *
+ * Note: each time this function is called, the initial size is
+ * changed to the given value. Already existing elements are not
+ * affected. This function is usually meant to be called just once
+ * at start of an application, but there is no harm calling it more
+ * than once. Note that the function is NOT thread-safe and must not
+ * be called on different threads concurrently.
+ *
+ * @param size new initial size for printbuf (formatting buffer)
+ */
+extern void
+json_global_set_printbuf_initial_size(int size);
 #ifdef __cplusplus
 }
 #endif

--- a/printbuf.h
+++ b/printbuf.h
@@ -54,7 +54,7 @@ do {                                                         \
  * constructed. To do so, printbuf_terminate_string() must be
  * called first.
  */
-extern int
+extern void
 printbuf_memappend_no_nul(struct printbuf *p, const char *buf, int size);
 extern void
 printbuf_terminate_string(struct printbuf *const p);


### PR DESCRIPTION
This patch set optimized various aspects of generating the output json. Each patch is commented in depth. The performance is increased by a factor of ~3 for my use case.

Special consideration should go to https://github.com/json-c/json-c/commit/4969ffdcb2358a6f9d828073ec77114e138aba69 which introduces a new method of out of memory handling, which replaces the inconsistent previous method. Again, commit comment has all details.