### PR TITLE
Atomic updates for the refcount

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -161,11 +161,13 @@ static int json_escape_str(struct printbuf *pb, const char *str, int len)
 extern struct json_object* json_object_get(struct json_object *jso)
 {
 	if (!jso) return jso;
+
 #if defined __GNUC__
     __sync_add_and_fetch(&jso->_ref_count, 1);
 #else
     ++jso->_ref_count;
 #endif        
+
 	return jso;
 }
 

--- a/json_object.c
+++ b/json_object.c
@@ -160,25 +160,29 @@ static int json_escape_str(struct printbuf *pb, const char *str, int len)
 
 extern struct json_object* json_object_get(struct json_object *jso)
 {
-	if (jso)
-		jso->_ref_count++;
+	if (!jso) return jso;
+#if defined __GNUC__
+    __sync_add_and_fetch(&jso->_ref_count, 1);
+#else
+    ++jso->_ref_count;
+#endif        
 	return jso;
 }
 
 int json_object_put(struct json_object *jso)
 {
-	if(jso)
-	{
-		jso->_ref_count--;
-		if(!jso->_ref_count)
-		{
-			if (jso->_user_delete)
-				jso->_user_delete(jso, jso->_userdata);
-			jso->_delete(jso);
-			return 1;
-		}
-	}
-	return 0;
+	if(!jso) return 0;
+
+#if defined __GNUC__
+    if (__sync_fetch_and_sub(&jso->_ref_count, 1) > 0) return 0;
+#else
+    if (--jso->_ref_count > 0) return 0;
+#endif
+
+    if (jso->_user_delete)
+        jso->_user_delete(jso, jso->_userdata);
+    jso->_delete(jso);
+    return 1;
 }
 
 

--- a/json_object.c
+++ b/json_object.c
@@ -176,7 +176,7 @@ int json_object_put(struct json_object *jso)
 	if(!jso) return 0;
 
 #if defined __GNUC__
-	if (__sync_fetch_and_sub(&jso->_ref_count, 1) > 0) return 0;
+	if (__sync_sub_and_fetch(&jso->_ref_count, 1) > 0) return 0;
 #else
 	if (--jso->_ref_count > 0) return 0;
 #endif

--- a/json_object.c
+++ b/json_object.c
@@ -163,9 +163,9 @@ extern struct json_object* json_object_get(struct json_object *jso)
 	if (!jso) return jso;
 
 #if defined __GNUC__
-    __sync_add_and_fetch(&jso->_ref_count, 1);
+	__sync_add_and_fetch(&jso->_ref_count, 1);
 #else
-    ++jso->_ref_count;
+	++jso->_ref_count;
 #endif        
 
 	return jso;
@@ -176,15 +176,15 @@ int json_object_put(struct json_object *jso)
 	if(!jso) return 0;
 
 #if defined __GNUC__
-    if (__sync_fetch_and_sub(&jso->_ref_count, 1) > 0) return 0;
+	if (__sync_fetch_and_sub(&jso->_ref_count, 1) > 0) return 0;
 #else
-    if (--jso->_ref_count > 0) return 0;
+	if (--jso->_ref_count > 0) return 0;
 #endif
 
-    if (jso->_user_delete)
-        jso->_user_delete(jso, jso->_userdata);
-    jso->_delete(jso);
-    return 1;
+	if (jso->_user_delete)
+		jso->_user_delete(jso, jso->_userdata);
+	jso->_delete(jso);
+	return 1;
 }
 
 


### PR DESCRIPTION
I've modified the json_object_get() and json_object_put() functions to use atomic updates of the refcount. This allows json objects to be safely moved and copied between threads.

It uses the atomic builtin functions of GCC (see https://gcc.gnu.org/onlinedocs/gcc-4.1.2/gcc/Atomic-Builtins.html). These functions are also already used inside the linkhash.c file of this json-c library, so I think that it is not much of a problem that they will be used inside json_object.c too.