### PR TITLE
configure: check realloc with AC_CHECK_FUNCS() to fix cross-compilation.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ AC_TYPE_SIZE_T
 # Checks for library functions.
 AC_FUNC_VPRINTF
 AC_FUNC_MEMCMP
-AC_FUNC_REALLOC
+AC_CHECK_FUNCS([realloc])
 AC_CHECK_FUNCS(strcasecmp strdup strerror snprintf vsnprintf vasprintf open vsyslog strncasecmp setlocale)
 AC_CHECK_DECLS([INFINITY], [], [], [[#include <math.h>]])
 AC_CHECK_DECLS([nan], [], [], [[#include <math.h>]])


### PR DESCRIPTION
AC_FUNC_REALLOC is messed up when cross-compiling, ending up in failed
build with "undefined reference to `rpl_realloc'" error.
AC_CHECK_FUNCS will work both with "usual" and cross builds.

= More Info =

The build fails with:

> make[2]: Entering directory '/home/jehan/dev/src/json-c'
  CCLD     libjson-c.la
.libs/arraylist.o: In function `array_list_expand_internal':
/home/jehan/dev/src/json-c/arraylist.c:68: undefined reference to `rpl_realloc'
.libs/printbuf.o: In function `printbuf_extend':
/home/jehan/dev/src/json-c/printbuf.c:73: undefined reference to `rpl_realloc'
collect2: error: ld returned 1 exit status
Makefile:542: recipe for target 'libjson-c.la' failed
make[2]: *** [libjson-c.la] Error 1
make[2]: Leaving directory '/home/jehan/dev/src/json-c'
Makefile:640: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/home/jehan/dev/src/json-c'
Makefile:441: recipe for target 'all' failed
make: *** [all] Error 2

While searching the web, you can find a lot of occurrences of this issue when cross-compiling various projects. Some people suggest to export an environment variable (ac_cv_func_malloc_0_nonnull=yes) to bypass the problem, but it did not work for me; and anyway this is clearly not the right solution. The real problem is that the configure test is wrong and should work for native builds as well as cross builds.
See for instance this page: http://rickfoosusa.blogspot.fr/2011/11/howto-fix-undefined-reference-to.html
The proposed fix works and allowed me to cross-compile json-c for Windows from my Linux machine without a problem.