### PR TITLE
Fix various potential null ptr deref and int32 overflows

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -934,6 +934,11 @@ struct json_object* json_object_new_array(void)
 	jso->_delete = &json_object_array_delete;
 	jso->_to_json_string = &json_object_array_to_json_string;
 	jso->o.c_array = array_list_new(&json_object_array_entry_free);
+        if(jso->o.c_array == NULL)
+	{
+	    free(jso);
+	    return NULL;
+	}
 	return jso;
 }
 


### PR DESCRIPTION
This fix errors that can happen when ingesting very large JSON files
when hitting the maximum heap size of the process.