### PR TITLE
Use stdint.h to check for size_t size

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,7 +109,7 @@ AX_APPEND_COMPILE_FLAGS([-D_GNU_SOURCE -D_REENTRANT])
 
 AX_COMPILE_CHECK_SIZEOF(int)
 AX_COMPILE_CHECK_SIZEOF(long)
-AX_COMPILE_CHECK_SIZEOF(size_t, [#include "json_inttypes.h"])
+AX_COMPILE_CHECK_SIZEOF(size_t, [#include <stdint.h>])
 
 AC_CONFIG_FILES([
 Makefile


### PR DESCRIPTION
If we use json_inttypes.h we are going to fail when builddir != srcdir,
and since JSON_C_HAVE_INTTYPES_H is defined after the configure script
has run, including json_inttypes.h would be the equivalent on including
stdint.h anyway.

This fixes the build of json-c in the GNOME Continuous builder.