### PR TITLE
Fix size_t size check for first-time builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,7 +109,7 @@ AX_APPEND_COMPILE_FLAGS([-D_GNU_SOURCE -D_REENTRANT])
 
 AX_COMPILE_CHECK_SIZEOF(int)
 AX_COMPILE_CHECK_SIZEOF(long)
-AX_COMPILE_CHECK_SIZEOF(size_t, [#include "json_inttypes.h"])
+AX_COMPILE_CHECK_SIZEOF(size_t, [#include <stddef.h>])
 
 AC_CONFIG_FILES([
 Makefile


### PR DESCRIPTION
json_inttypes.h includes json_config.h, which is not available before
configure has run successfully at least once. Change configure check to
include stddef.h instead, which defines size_t.