### PR TITLE
Add public API to use userdata independently of custom serializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@
 /tests/test_parse
 /tests/test_cast
 /tests/test_charcase
+/tests/test_double_serializer
 /tests/test_locale
 /tests/test_null
 /tests/test_printbuf

--- a/json_object.c
+++ b/json_object.c
@@ -235,6 +235,21 @@ enum json_type json_object_get_type(const struct json_object *jso)
 	return jso->o_type;
 }
 
+void* json_object_get_userdata(json_object *jso) {
+	return jso->_userdata;
+}
+
+void json_object_set_userdata(json_object *jso, void *userdata,
+			      json_object_delete_fn *user_delete)
+{
+	// First, clean up any previously existing user info
+	if (jso->_user_delete)
+		jso->_user_delete(jso, jso->_userdata);
+
+	jso->_userdata = userdata;
+	jso->_user_delete = user_delete;
+}
+
 /* set a custom conversion to string */
 
 void json_object_set_serializer(json_object *jso,
@@ -242,13 +257,7 @@ void json_object_set_serializer(json_object *jso,
 	void *userdata,
 	json_object_delete_fn *user_delete)
 {
-	// First, clean up any previously existing user info
-	if (jso->_user_delete)
-	{
-		jso->_user_delete(jso, jso->_userdata);
-	}
-	jso->_userdata = NULL;
-	jso->_user_delete = NULL;
+	json_object_set_userdata(jso, userdata, user_delete);
 
 	if (to_string_func == NULL)
 	{
@@ -281,8 +290,6 @@ void json_object_set_serializer(json_object *jso,
 	}
 
 	jso->_to_json_string = to_string_func;
-	jso->_userdata = userdata;
-	jso->_user_delete = user_delete;
 }
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -11,6 +11,7 @@ TESTS+= testReplaceExisting.test
 TESTS+= test_parse_int64.test
 TESTS+= test_null.test
 TESTS+= test_cast.test
+TESTS+= test_double_serializer.test
 TESTS+= test_parse.test
 TESTS+= test_locale.test
 TESTS+= test_charcase.test
@@ -22,7 +23,7 @@ check_PROGRAMS=
 check_PROGRAMS += $(TESTS:.test=)
 
 # Note: handled by test1.test
-check_PROGRAMS += test1Formatted 
+check_PROGRAMS += test1Formatted
 test1Formatted_SOURCES = test1.c parse_flags.c
 test1Formatted_CPPFLAGS = -DTEST_FORMATTED
 

--- a/tests/test_double_serializer.c
+++ b/tests/test_double_serializer.c
@@ -1,0 +1,31 @@
+/*
+* Tests if the format string for double serialization is handled correctly
+*/
+
+#include <stdio.h>
+#include "config.h"
+
+#include "json_object.h"
+#include "json_object_private.h"
+
+int main()
+{
+	struct json_object *obj = json_object_new_double(0.5);
+
+	printf("Test default serializer:\n");
+	printf("obj.to_string(standard)=%s\n", json_object_to_json_string(obj));
+
+	printf("Test default serializer with custom userdata:\n");
+	obj->_userdata = "test";
+	printf("obj.to_string(userdata)=%s\n", json_object_to_json_string(obj));
+
+	printf("Test explicit serializer with custom userdata:\n");
+	json_object_set_serializer(obj, json_object_double_to_json_string, "test", NULL);
+	printf("obj.to_string(custom)=%s\n", json_object_to_json_string(obj));
+
+	printf("Test reset serializer:\n");
+	json_object_set_serializer(obj, NULL, NULL, NULL);
+	printf("obj.to_string(reset)=%s\n", json_object_to_json_string(obj));
+
+	json_object_put(obj);
+}

--- a/tests/test_double_serializer.expected
+++ b/tests/test_double_serializer.expected
@@ -1,0 +1,8 @@
+Test default serializer:
+obj.to_string(standard)=0.5
+Test default serializer with custom userdata:
+obj.to_string(userdata)=0.5
+Test explicit serializer with custom userdata:
+obj.to_string(custom)=test
+Test reset serializer:
+obj.to_string(reset)=0.5

--- a/tests/test_double_serializer.test
+++ b/tests/test_double_serializer.test
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Common definitions
+if test -z "$srcdir"; then
+    srcdir="${0%/*}"
+    test "$srcdir" = "$0" && srcdir=.
+    test -z "$srcdir" && srcdir=.
+fi
+. "$srcdir/test-defs.sh"
+
+run_output_test test_double_serializer
+exit $?


### PR DESCRIPTION
As mentioned on the mailing list, I'd find it useful to be able to use the userdata field for custom data. This PR changes the default serializer for doubles to ignore the userdata again and adds API for userdata.