### PR TITLE
linkhash.c: optimised the table_free path

### DIFF
--- a/linkhash.c
+++ b/linkhash.c
@@ -562,10 +562,9 @@ int lh_table_resize(struct lh_table *t, int new_size)
 void lh_table_free(struct lh_table *t)
 {
 	struct lh_entry *c;
-	for(c = t->head; c != NULL; c = c->next) {
-		if(t->free_fn) {
+	if(t->free_fn) {
+		for(c = t->head; c != NULL; c = c->next)
 			t->free_fn(c);
-		}
 	}
 	free(t->table);
 	free(t);

--- a/linkhash.h
+++ b/linkhash.h
@@ -175,7 +175,6 @@ extern struct lh_table* lh_table_new(int size,
  * Convenience function to create a new linkhash
  * table with char keys.
  * @param size initial table size.
- * @param name table name.
  * @param free_fn callback function used to free memory for entries.
  * @return On success, a pointer to the new linkhash table is returned.
  * 	On error, a null pointer is returned.
@@ -188,7 +187,6 @@ extern struct lh_table* lh_kchar_table_new(int size,
  * Convenience function to create a new linkhash
  * table with ptr keys.
  * @param size initial table size.
- * @param name table name.
  * @param free_fn callback function used to free memory for entries.
  * @return On success, a pointer to the new linkhash table is returned.
  * 	On error, a null pointer is returned.


### PR DESCRIPTION
Doing unconditional free call if  the free callback is available instead of checking for callback  availability for every entry of hashmap