### PR TITLE
initialize null terminator of new printbuf

### DIFF
--- a/printbuf.c
+++ b/printbuf.c
@@ -42,6 +42,7 @@ struct printbuf* printbuf_new(void)
     free(p);
     return NULL;
   }
+  p->buf[0]= '\0';
   return p;
 }
 


### PR DESCRIPTION
It's possible (e.g. by using json_object_from_file() on an empty file)
to get json-c to try to use a printbuf that has never had anything
written to it. Before this change, it could access a string that
should be length zero, but was never initialized, and could
theoretically have an unexpected string.

I ran into this while using valgrind on an application's tests that sometimes
specified an empty json configuration file. So I guess the main motivation of
this PR is to shut up valgrind :)

But, I was able to come up with a sort of proof-of-concept of actual harm from the bug:

```c
#include <fcntl.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>

#include "json.h"
#include "json_util.h"

const char *test_file = "test_attack.json";

int main() {
	int fd = open(test_file, O_CREAT | O_TRUNC);
	if (fd < 0) {
		perror("failed to open test file");
		return 1;
	}
	close(fd);

	int i;
	char *bufs[4];
	for (i = 0; i < 4; i++) {
		bufs[i] = malloc(32);
		strcpy(bufs[i], "{\"evil\": true}");
	}
	for (i = 0; i < 3; i++) {
		free(bufs[i]);
	}

	json_object *jso = json_object_from_file(test_file);
	if (jso != NULL) {
		fprintf(stderr, "! json from empty file ! %s\n", json_object_get_string(jso));
		return 1;
	}
	return 0;
}
```

```
$ ./test_attack 
! json from empty file ! { "evil": true }
```

EDIT: tweaked example code loop counts to make the trick work on more systems