### PR TITLE
getting error in date string 19\/07\/2016, fixed for error 19/07/2016

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -139,7 +139,7 @@ static int json_escape_str(struct printbuf *pb, const char *str, int len, int fl
 			else if(c == '\f') printbuf_memappend(pb, "\\f", 2);
 			else if(c == '"') printbuf_memappend(pb, "\\\"", 2);
 			else if(c == '\\') printbuf_memappend(pb, "\\\\", 2);
-			else if(c == '/') printbuf_memappend(pb, "\\/", 2);
+			else if(c == '/') printbuf_memappend(pb, "/", 1);
 
 			start_offset = ++pos;
 			break;

--- a/tests/test_parse.c
+++ b/tests/test_parse.c
@@ -226,7 +226,7 @@ struct incremental_step {
 	{ "\"\\n\"",         -1, -1, json_tokener_success, 0 },
 	{ "\"\\r\"",         -1, -1, json_tokener_success, 0 },
 	{ "\"\\t\"",         -1, -1, json_tokener_success, 0 },
-	{ "\"\\/\"",         -1, -1, json_tokener_success, 0 },
+	{ "\"/\"",         -1, -1, json_tokener_success, 0 },
 	// Escaping a forward slash is optional
 	{ "\"/\"",           -1, -1, json_tokener_success, 0 },
 


### PR DESCRIPTION
Hello,

While using json-c library, whenever date has to be sent as a string, library creates some invalid "\\/" string within date.

See below example :

Before changing JSON library code :
{
	"String Node" : "19\/07\/2016"
}

After changing JSON library code :
{
	"String Node" : "19/07/2016"
}

Please accept this pull request so that other's will NOT face this issue.

Thanks.