### PR TITLE
Add Cmakefile and fix compiler warning.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,54 @@
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+cmake_minimum_required(VERSION 2.8.11)
+project(json-c)
+
+if(MSVC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4100 /wd4996 /wd4244 /wd4706 /wd4702 /wd4127 /wd4701")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4100 /wd4996 /wd4244 /wd4706 /wd4702 /wd4127 /wd4701")
+elseif(LINUX)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+endif()
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
+
+file(COPY ./config.h.win32 DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/include/)
+file(RENAME ${CMAKE_CURRENT_BINARY_DIR}/include/config.h.win32 ${CMAKE_CURRENT_BINARY_DIR}/include/config.h)
+
+file(COPY ./json_config.h.win32 DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/include/)
+file(RENAME ${CMAKE_CURRENT_BINARY_DIR}/include/json_config.h.win32 ${CMAKE_CURRENT_BINARY_DIR}/include/json_config.h)
+
+set(JSON_C_HEADERS
+    ./json.h
+    ${CMAKE_CURRENT_BINARY_DIR}/include/config.h
+    ./json_config.h
+    ./arraylist.h
+    ./debug.h
+    ./json_inttypes.h
+    ./json_object.h
+    ./json_object_private.h
+    ./json_tokener.h
+    ./json_util.h
+    ./linkhash.h
+    ./math_compat.h
+    ./printbuf.h
+    ./random_seed.h
+)
+
+set(JSON_C_SOURCES
+    ./arraylist.c
+    ./debug.c
+    ./json_object.c
+    ./json_tokener.c
+    ./json_util.c
+    ./linkhash.c
+    ./printbuf.c
+    ./random_seed.c
+)
+
+add_library(json-c
+    ${JSON_C_SOURCES}
+    ${JSON_C_HEADERS}
+    )
+

--- a/json_object.c
+++ b/json_object.c
@@ -447,8 +447,8 @@ struct lh_table* json_object_get_object(const struct json_object *jso)
 }
 
 int json_object_object_add_ex(struct json_object* jso,
-	const char *const key,
-	struct json_object *const val,
+	const char * key,
+	struct json_object * val,
 	const unsigned opts)
 {
 	// We lookup the entry and replace the value, rather than just deleting

--- a/json_object.c
+++ b/json_object.c
@@ -447,8 +447,8 @@ struct lh_table* json_object_get_object(const struct json_object *jso)
 }
 
 int json_object_object_add_ex(struct json_object* jso,
-	const char * key,
-	struct json_object * val,
+	const char *const key,
+	struct json_object *const val,
 	const unsigned opts)
 {
 	// We lookup the entry and replace the value, rather than just deleting


### PR DESCRIPTION
A cmake file is handy for devs who target multiple OSes including windows.
It has not been tested on non-Windows platforms but it should work.

