### PR TITLE
Support for 64 bit pointers on Windows

### DIFF
--- a/linkhash.h
+++ b/linkhash.h
@@ -341,7 +341,7 @@ static inline unsigned long lh_get_hash(const struct lh_table *t, const void *k)
 #ifdef __UNCONST
 #define _LH_UNCONST(a) __UNCONST(a)
 #else
-#define _LH_UNCONST(a) ((void *)(unsigned long)(const void *)(a))
+#define _LH_UNCONST(a) ((void *)(uintptr_t)(const void *)(a))
 #endif
 
 /**


### PR DESCRIPTION
While using the library on a 64 bit application there where problems because of a 32 bit truncation of a pointer.
This patch changes the unsigned long to the C99 uintptr_t that considers the architecture in which the library is compiled.