### PR TITLE
Fix _GNU_SOURCE define for vasprintf

### DIFF
--- a/printbuf.c
+++ b/printbuf.c
@@ -13,6 +13,7 @@
  * (http://www.opensource.org/licenses/mit-license.php)
  */
 
+#define _GNU_SOURCE
 #include "config.h"
 
 #include <stdio.h>


### PR DESCRIPTION
Without the `#define` it errors with:
```
error: implicit declaration of function ‘vasprintf’ [-Werror=implicit-function-declaration]
     if((size = vasprintf(&t, msg, ap)) < 0) { va_end(ap); return -1; }
```