### PR TITLE
duplicate an json_object

### DIFF
--- a/json_util.c
+++ b/json_util.c
@@ -324,3 +324,16 @@ const char *json_type_to_name(enum json_type o_type)
 	return json_type_name[o_type];
 }
 
+struct json_object* json_object_duplicate(struct json_object* pObj)
+{
+	/*we could also duplicate by iterate json_object;
+		but this code is easy to read and write.
+	*/
+	const char* pTxt = json_object_to_json_string(pObj);
+	if (pTxt) 
+	{
+		json_object* newObject = json_tokener_parse(pTxt);
+		return newObject;
+	}
+	return NULL;
+}

--- a/json_util.h
+++ b/json_util.h
@@ -82,6 +82,13 @@ extern int json_parse_double(const char *buf, double *retval);
  */
 extern const char *json_type_to_name(enum json_type o_type);
 
+/** duplilcate a json_object.
+* Not thread safe, because of obj need to convert to string first
+* @param obj the json_object instance
+* @returns a new json object, remember when you newjson object should release by yourself
+*/
+extern struct json_object* json_object_duplicate(const struct json_object* obj);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
I add an function json_object_duplicate to duplicate an json_object. Do you accept this PR?