### PR TITLE
Improve json_object -> string performance

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -147,9 +147,13 @@ static int json_escape_str(struct printbuf *pb, const char *str, int len, int fl
 					printbuf_memappend(pb,
 							   str + start_offset,
 							   pos - start_offset);
-				sprintbuf(pb, "\\u00%c%c",
-				json_hex_chars[c >> 4],
-				json_hex_chars[c & 0xf]);
+				static char sbuf[7];
+				snprintf(sbuf, sizeof(sbuf),
+                                        "\\u00%c%c",
+                                        json_hex_chars[c >> 4],
+                                        json_hex_chars[c & 0xf]);
+				printbuf_memappend (pb, sbuf, sizeof(sbuf) - 1);
+
 				start_offset = ++pos;
 			} else
 				pos++;
@@ -585,7 +589,10 @@ static int json_object_int_to_json_string(struct json_object* jso,
 					  int level,
 					  int flags)
 {
-	return sprintbuf(pb, "%" PRId64, jso->o.c_int64);
+	/* room for 19 digits, the sign char, and a null term */
+	static char sbuf[21];
+	snprintf(sbuf, sizeof(sbuf), "%"PRId64, jso->o.c_int64);
+	return sprintbuf(pb, sbuf);
 }
 
 struct json_object* json_object_new_int(int32_t i)

--- a/json_object.c
+++ b/json_object.c
@@ -149,11 +149,10 @@ static int json_escape_str(struct printbuf *pb, const char *str, int len, int fl
 							   pos - start_offset);
 				static char sbuf[7];
 				snprintf(sbuf, sizeof(sbuf),
-                                        "\\u00%c%c",
-                                        json_hex_chars[c >> 4],
-                                        json_hex_chars[c & 0xf]);
-				printbuf_memappend (pb, sbuf, sizeof(sbuf) - 1);
-
+					 "\\u00%c%c",
+					 json_hex_chars[c >> 4],
+					 json_hex_chars[c & 0xf]);
+				printbuf_memappend_fast(pb, sbuf, (int) sizeof(sbuf) - 1);
 				start_offset = ++pos;
 			} else
 				pos++;
@@ -364,29 +363,29 @@ static int json_object_object_to_json_string(struct json_object* jso,
 	int had_children = 0;
 	struct json_object_iter iter;
 
-	sprintbuf(pb, "{" /*}*/);
+	printbuf_strappend(pb, "{" /*}*/);
 	if (flags & JSON_C_TO_STRING_PRETTY)
-		sprintbuf(pb, "\n");
+		printbuf_strappend(pb, "\n");
 	json_object_object_foreachC(jso, iter)
 	{
 		if (had_children)
 		{
-			sprintbuf(pb, ",");
+			printbuf_strappend(pb, ",");
 			if (flags & JSON_C_TO_STRING_PRETTY)
-				sprintbuf(pb, "\n");
+				printbuf_strappend(pb, "\n");
 		}
 		had_children = 1;
 		if (flags & JSON_C_TO_STRING_SPACED)
-			sprintbuf(pb, " ");
+			printbuf_strappend(pb, " ");
 		indent(pb, level+1, flags);
-		sprintbuf(pb, "\"");
+		printbuf_strappend(pb, "\"");
 		json_escape_str(pb, iter.key, strlen(iter.key), flags);
 		if (flags & JSON_C_TO_STRING_SPACED)
-			sprintbuf(pb, "\": ");
+			printbuf_strappend(pb, "\": ");
 		else
-			sprintbuf(pb, "\":");
+			printbuf_strappend(pb, "\":");
 		if(iter.val == NULL)
-			sprintbuf(pb, "null");
+			printbuf_strappend(pb, "null");
 		else
 			if (iter.val->_to_json_string(iter.val, pb, level+1,flags) < 0)
 				return -1;
@@ -394,13 +393,13 @@ static int json_object_object_to_json_string(struct json_object* jso,
 	if (flags & JSON_C_TO_STRING_PRETTY)
 	{
 		if (had_children)
-			sprintbuf(pb, "\n");
+			printbuf_strappend(pb, "\n");
 		indent(pb,level,flags);
 	}
 	if (flags & JSON_C_TO_STRING_SPACED)
-		return sprintbuf(pb, /*{*/ " }");
+		return printbuf_strappend(pb, /*{*/ " }");
 	else
-		return sprintbuf(pb, /*{*/ "}");
+		return printbuf_strappend(pb, /*{*/ "}");
 }
 
 
@@ -541,8 +540,8 @@ static int json_object_boolean_to_json_string(struct json_object* jso,
 					      int flags)
 {
 	if (jso->o.c_boolean)
-		return sprintbuf(pb, "true");
-	return sprintbuf(pb, "false");
+		return printbuf_strappend(pb, "true");
+	return printbuf_strappend(pb, "false");
 }
 
 struct json_object* json_object_new_boolean(json_bool b)
@@ -592,7 +591,7 @@ static int json_object_int_to_json_string(struct json_object* jso,
 	/* room for 19 digits, the sign char, and a null term */
 	static char sbuf[21];
 	snprintf(sbuf, sizeof(sbuf), "%"PRId64, jso->o.c_int64);
-	return sprintbuf(pb, sbuf);
+	return printbuf_memappend (pb, sbuf, strlen(sbuf));
 }
 
 struct json_object* json_object_new_int(int32_t i)
@@ -860,9 +859,9 @@ static int json_object_string_to_json_string(struct json_object* jso,
 					     int level,
 					     int flags)
 {
-	sprintbuf(pb, "\"");
+	printbuf_strappend(pb, "\"");
 	json_escape_str(pb, get_string_component(jso), jso->o.c_string.len, flags);
-	sprintbuf(pb, "\"");
+	printbuf_strappend(pb, "\"");
 	return 0;
 }
 
@@ -979,25 +978,25 @@ static int json_object_array_to_json_string(struct json_object* jso,
 	int had_children = 0;
 	size_t ii;
 
-	sprintbuf(pb, "[");
+	printbuf_strappend(pb, "[");
 	if (flags & JSON_C_TO_STRING_PRETTY)
-		sprintbuf(pb, "\n");
+		printbuf_strappend(pb, "\n");
 	for(ii=0; ii < json_object_array_length(jso); ii++)
 	{
 		struct json_object *val;
 		if (had_children)
 		{
-			sprintbuf(pb, ",");
+			printbuf_strappend(pb, ",");
 			if (flags & JSON_C_TO_STRING_PRETTY)
-				sprintbuf(pb, "\n");
+				printbuf_strappend(pb, "\n");
 		}
 		had_children = 1;
 		if (flags & JSON_C_TO_STRING_SPACED)
-			sprintbuf(pb, " ");
+			printbuf_strappend(pb, " ");
 		indent(pb, level + 1, flags);
 		val = json_object_array_get_idx(jso, ii);
 		if(val == NULL)
-			sprintbuf(pb, "null");
+			printbuf_strappend(pb, "null");
 		else
 			if (val->_to_json_string(val, pb, level+1, flags) < 0)
 				return -1;
@@ -1005,13 +1004,13 @@ static int json_object_array_to_json_string(struct json_object* jso,
 	if (flags & JSON_C_TO_STRING_PRETTY)
 	{
 		if (had_children)
-			sprintbuf(pb, "\n");
+			printbuf_strappend(pb, "\n");
 		indent(pb,level,flags);
 	}
 
 	if (flags & JSON_C_TO_STRING_SPACED)
-		return sprintbuf(pb, " ]");
-	return sprintbuf(pb, "]");
+		return printbuf_strappend(pb, " ]");
+	return printbuf_strappend(pb, "]");
 }
 
 static void json_object_array_entry_free(void *data)

--- a/printbuf.c
+++ b/printbuf.c
@@ -85,6 +85,7 @@ int printbuf_memappend(struct printbuf *p, const char *buf, int size)
     if (printbuf_extend(p, p->bpos + size + 1) < 0)
       return -1;
   }
+
   memcpy(p->buf + p->bpos, buf, size);
   p->bpos += size;
   p->buf[p->bpos]= '\0';
@@ -111,34 +112,6 @@ int printbuf_memset(struct printbuf *pb, int offset, int charvalue, int len)
 	return 0;
 }
 
-int sprintbuf(struct printbuf *p, const char *msg, ...)
-{
-  va_list ap;
-  char *t;
-  int size;
-  char buf[128];
-
-  /* user stack buffer first */
-  va_start(ap, msg);
-  size = vsnprintf(buf, 128, msg, ap);
-  va_end(ap);
-  /* if string is greater than stack buffer, then use dynamic string
-     with vasprintf.  Note: some implementation of vsnprintf return -1
-     if output is truncated whereas some return the number of bytes that
-     would have been written - this code handles both cases. */
-  if(size == -1 || size > 127) {
-    va_start(ap, msg);
-    if((size = vasprintf(&t, msg, ap)) < 0) { va_end(ap); return -1; }
-    va_end(ap);
-    printbuf_memappend(p, t, size);
-    free(t);
-    return size;
-  } else {
-    printbuf_memappend(p, buf, size);
-    return size;
-  }
-}
-
 void printbuf_reset(struct printbuf *p)
 {
   p->buf[0] = '\0';
@@ -151,4 +124,9 @@ void printbuf_free(struct printbuf *p)
     free(p->buf);
     free(p);
   }
+}
+
+inline int sprintbuf(struct printbuf *p, const char *buf)
+{
+  return printbuf_memappend(p, buf, strlen(buf));
 }

--- a/printbuf.c
+++ b/printbuf.c
@@ -85,7 +85,6 @@ int printbuf_memappend(struct printbuf *p, const char *buf, int size)
     if (printbuf_extend(p, p->bpos + size + 1) < 0)
       return -1;
   }
-
   memcpy(p->buf + p->bpos, buf, size);
   p->bpos += size;
   p->buf[p->bpos]= '\0';
@@ -112,6 +111,34 @@ int printbuf_memset(struct printbuf *pb, int offset, int charvalue, int len)
 	return 0;
 }
 
+int sprintbuf(struct printbuf *p, const char *msg, ...)
+{
+  va_list ap;
+  char *t;
+  int size;
+  char buf[128];
+
+  /* user stack buffer first */
+  va_start(ap, msg);
+  size = vsnprintf(buf, 128, msg, ap);
+  va_end(ap);
+  /* if string is greater than stack buffer, then use dynamic string
+     with vasprintf.  Note: some implementation of vsnprintf return -1
+     if output is truncated whereas some return the number of bytes that
+     would have been written - this code handles both cases. */
+  if(size == -1 || size > 127) {
+    va_start(ap, msg);
+    if((size = vasprintf(&t, msg, ap)) < 0) { va_end(ap); return -1; }
+    va_end(ap);
+    printbuf_memappend(p, t, size);
+    free(t);
+    return size;
+  } else {
+    printbuf_memappend(p, buf, size);
+    return size;
+  }
+}
+
 void printbuf_reset(struct printbuf *p)
 {
   p->buf[0] = '\0';
@@ -124,9 +151,4 @@ void printbuf_free(struct printbuf *p)
     free(p->buf);
     free(p);
   }
-}
-
-inline int sprintbuf(struct printbuf *p, const char *buf)
-{
-  return printbuf_memappend(p, buf, strlen(buf));
 }

--- a/printbuf.h
+++ b/printbuf.h
@@ -62,7 +62,7 @@ extern int
 printbuf_memset(struct printbuf *pb, int offset, int charvalue, int len);
 
 extern int
-sprintbuf(struct printbuf *p, const char *msg, ...);
+sprintbuf(struct printbuf *p, const char *msg);
 
 extern void
 printbuf_reset(struct printbuf *p);

--- a/printbuf.h
+++ b/printbuf.h
@@ -29,12 +29,13 @@ struct printbuf {
 extern struct printbuf*
 printbuf_new(void);
 
-/* As an optimization, printbuf_memappend_fast is defined as a macro
+/* As an optimization, printbuf_memappend_fast() is defined as a macro
  * that handles copying data if the buffer is large enough; otherwise
- * it invokes printbuf_memappend_real() which performs the heavy
+ * it invokes printbuf_memappend() which performs the heavy
  * lifting of realloc()ing the buffer and copying data.
- * Your code should not use printbuf_memappend directly--use
- * printbuf_memappend_fast instead.
+ *
+ * Your code should not use printbuf_memappend() directly unless it
+ * checks the return code. Use printbuf_memappend_fast() instead.
  */
 extern int
 printbuf_memappend(struct printbuf *p, const char *buf, int size);
@@ -51,6 +52,28 @@ do {                                                         \
 #define printbuf_length(p) ((p)->bpos)
 
 /**
+ * Results in a compile error if the argument is not a string literal.
+ */
+#define _printbuf_check_literal(mystr) ("" mystr)
+
+/**
+ * This is an optimization wrapper around printbuf_memappend() that is useful
+ * for appending string literals. Since the size of string constants is known
+ * at compile time, using this macro can avoid a costly strlen() call. This is
+ * especially helpful when a constant string must be appended many times. If
+ * you got here because of a compilation error caused by passing something
+ * other than a string literal, use printbuf_memappend_fast() in conjunction
+ * with strlen().
+ *
+ * See also:
+ *   printbuf_memappend_fast()
+ *   printbuf_memappend()
+ *   sprintbuf()
+ */
+#define printbuf_strappend(pb, str) \
+   printbuf_memappend ((pb), _printbuf_check_literal(str), sizeof(str) - 1)
+
+/**
  * Set len bytes of the buffer to charvalue, starting at offset offset.
  * Similar to calling memset(x, charvalue, len);
  *
@@ -61,8 +84,22 @@ do {                                                         \
 extern int
 printbuf_memset(struct printbuf *pb, int offset, int charvalue, int len);
 
+/**
+ * Formatted print to printbuf.
+ *
+ * This function is the most expensive of the available functions for appending
+ * string data to a printbuf and should be used only where convenience is more
+ * important than speed. Avoid using this function in high performance code or
+ * tight loops; in these scenarios, consider using snprintf() with a static
+ * buffer in conjunction with one of the printbuf_*append() functions.
+ *
+ * See also:
+ *   printbuf_memappend_fast()
+ *   printbuf_memappend()
+ *   printbuf_strappend()
+ */
 extern int
-sprintbuf(struct printbuf *p, const char *msg);
+sprintbuf(struct printbuf *p, const char *msg, ...);
 
 extern void
 printbuf_reset(struct printbuf *p);

--- a/tests/test_printbuf.c
+++ b/tests/test_printbuf.c
@@ -17,7 +17,7 @@ static void test_basic_printbuf_memset()
 
 	printf("%s: starting test\n", __func__);
 	pb = printbuf_new();
-	sprintbuf(pb, "blue:%d", 1);
+	sprintbuf(pb, "blue:1");
 	printbuf_memset(pb, -1, 'x', 52);
 	printf("Buffer contents:%.*s\n", printbuf_length(pb), pb->buf);
 	printbuf_free(pb);
@@ -111,42 +111,6 @@ static void test_printbuf_memappend(int *before_resize)
 	printf("%s: end test\n", __func__);
 }
 
-static void test_sprintbuf(int before_resize);
-static void test_sprintbuf(int before_resize)
-{
-	struct printbuf *pb;
-
-	printf("%s: starting test\n", __func__);
-	pb = printbuf_new();
-	printf("Buffer length: %d\n", printbuf_length(pb));
-
-	char *data = malloc(before_resize + 1 + 1);
-	memset(data, 'X', before_resize + 1 + 1);
-	data[before_resize + 1] = '\0';
-	sprintbuf(pb, "%s", data);
-	free(data);
-	printf("sprintbuf to just after resize(%d+1): %d, [%s], strlen(buf)=%d\n", before_resize, printbuf_length(pb), pb->buf, (int)strlen(pb->buf));
-
-	printbuf_reset(pb);
-	sprintbuf(pb, "plain");
-	printf("%d, [%s]\n", printbuf_length(pb), pb->buf);
-
-	sprintbuf(pb, "%d", 1);
-	printf("%d, [%s]\n", printbuf_length(pb), pb->buf);
-
-	sprintbuf(pb, "%d", INT_MAX);
-	printf("%d, [%s]\n", printbuf_length(pb), pb->buf);
-
-	sprintbuf(pb, "%d", INT_MIN);
-	printf("%d, [%s]\n", printbuf_length(pb), pb->buf);
-
-	sprintbuf(pb, "%s", "%s");
-	printf("%d, [%s]\n", printbuf_length(pb), pb->buf);
-
-	printbuf_free(pb);
-	printf("%s: end test\n", __func__);
-}
-
 int main(int argc, char **argv)
 {
 	int before_resize = 0;
@@ -158,8 +122,6 @@ int main(int argc, char **argv)
 	test_printbuf_memset_length();
 	printf("========================================\n");
 	test_printbuf_memappend(&before_resize);
-	printf("========================================\n");
-	test_sprintbuf(before_resize);
 	printf("========================================\n");
 
 	return 0;

--- a/tests/test_printbuf.c
+++ b/tests/test_printbuf.c
@@ -17,7 +17,7 @@ static void test_basic_printbuf_memset()
 
 	printf("%s: starting test\n", __func__);
 	pb = printbuf_new();
-	sprintbuf(pb, "blue:1");
+	sprintbuf(pb, "blue:%d", 1);
 	printbuf_memset(pb, -1, 'x', 52);
 	printf("Buffer contents:%.*s\n", printbuf_length(pb), pb->buf);
 	printbuf_free(pb);
@@ -106,6 +106,49 @@ static void test_printbuf_memappend(int *before_resize)
 	printf("Append to just after resize: %d, [%s]\n", printbuf_length(pb), pb->buf);
 
 	free(data);
+	printbuf_free(pb);
+
+#define SA_TEST_STR "XXXXXXXXXXXXXXXX"
+	pb = printbuf_new();
+	printbuf_strappend(pb, SA_TEST_STR);
+	printf("Buffer size after printbuf_strappend(): %d, [%s]\n", printbuf_length(pb), pb->buf);
+	printbuf_free(pb);
+#undef  SA_TEST_STR
+
+	printf("%s: end test\n", __func__);
+}
+
+static void test_sprintbuf(int before_resize);
+static void test_sprintbuf(int before_resize)
+{
+	struct printbuf *pb;
+
+	printf("%s: starting test\n", __func__);
+	pb = printbuf_new();
+	printf("Buffer length: %d\n", printbuf_length(pb));
+
+	char *data = malloc(before_resize + 1 + 1);
+	memset(data, 'X', before_resize + 1 + 1);
+	data[before_resize + 1] = '\0';
+	sprintbuf(pb, "%s", data);
+	free(data);
+	printf("sprintbuf to just after resize(%d+1): %d, [%s], strlen(buf)=%d\n", before_resize, printbuf_length(pb), pb->buf, (int)strlen(pb->buf));
+
+	printbuf_reset(pb);
+	sprintbuf(pb, "plain");
+	printf("%d, [%s]\n", printbuf_length(pb), pb->buf);
+
+	sprintbuf(pb, "%d", 1);
+	printf("%d, [%s]\n", printbuf_length(pb), pb->buf);
+
+	sprintbuf(pb, "%d", INT_MAX);
+	printf("%d, [%s]\n", printbuf_length(pb), pb->buf);
+
+	sprintbuf(pb, "%d", INT_MIN);
+	printf("%d, [%s]\n", printbuf_length(pb), pb->buf);
+
+	sprintbuf(pb, "%s", "%s");
+	printf("%d, [%s]\n", printbuf_length(pb), pb->buf);
 
 	printbuf_free(pb);
 	printf("%s: end test\n", __func__);
@@ -122,6 +165,8 @@ int main(int argc, char **argv)
 	test_printbuf_memset_length();
 	printf("========================================\n");
 	test_printbuf_memappend(&before_resize);
+	printf("========================================\n");
+	test_sprintbuf(before_resize);
 	printf("========================================\n");
 
 	return 0;

--- a/tests/test_printbuf.expected
+++ b/tests/test_printbuf.expected
@@ -20,13 +20,3 @@ Append to just before resize: 31, [XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX]
 Append to just after resize: 32, [XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX]
 test_printbuf_memappend: end test
 ========================================
-test_sprintbuf: starting test
-Buffer length: 0
-sprintbuf to just after resize(31+1): 32, [XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX], strlen(buf)=32
-5, [plain]
-6, [plain1]
-16, [plain12147483647]
-27, [plain12147483647-2147483648]
-29, [plain12147483647-2147483648%s]
-test_sprintbuf: end test
-========================================

--- a/tests/test_printbuf.expected
+++ b/tests/test_printbuf.expected
@@ -18,5 +18,16 @@ Partial append: 3, [blu]
 With embedded \0 character: 4, [ab]
 Append to just before resize: 31, [XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX]
 Append to just after resize: 32, [XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX]
+Buffer size after printbuf_strappend(): 16, [XXXXXXXXXXXXXXXX]
 test_printbuf_memappend: end test
+========================================
+test_sprintbuf: starting test
+Buffer length: 0
+sprintbuf to just after resize(31+1): 32, [XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX], strlen(buf)=32
+5, [plain]
+6, [plain1]
+16, [plain12147483647]
+27, [plain12147483647-2147483648]
+29, [plain12147483647-2147483648%s]
+test_sprintbuf: end test
 ========================================


### PR DESCRIPTION
Hi there! This is a performance-related patch to improve `json_object` -> string conversion.
It yields average performance gains of ~350% for large objects.

Breakdown
----------
A `perf` analysis of a tight loop around `json_object_to_json_string()` yields the following results:

![flamegraph_bad](https://cloud.githubusercontent.com/assets/6827003/22560264/f4a116ae-e941-11e6-937d-f392147f88f2.png)

As you can see the primary hotspot here is `sprintbuf()` - more specifically, `vsnprintf()` / `vfprintf()`. Digging deeper, it appears that every call to `sprintbuf()` results in a full init of a variadic list. Variadic functions in themselves are pretty slow; they become rather onerous in terms of performance when called in a tight loop, as is often the case when dumping large amounts of JSON. I took a closer look at the rest of `json-c` and found that almost every call to `sprintbuf()` does not make use of the formatting it wraps -- indeed, most calls pass a single argument:

```
~/json-c> rg "sprintbuf"
json_object.c
150:                            sprintbuf(pb, "\\u00%c%c",
363:    sprintbuf(pb, "{" /*}*/);
365:            sprintbuf(pb, "\n");
370:                    sprintbuf(pb, ",");
372:                            sprintbuf(pb, "\n");
376:                    sprintbuf(pb, " ");
378:            sprintbuf(pb, "\"");
381:                    sprintbuf(pb, "\": ");
383:                    sprintbuf(pb, "\":");
385:                    sprintbuf(pb, "null");
393:                    sprintbuf(pb, "\n");
397:            return sprintbuf(pb, /*{*/ " }");
399:            return sprintbuf(pb, /*{*/ "}");
540:            return sprintbuf(pb, "true");
541:    return sprintbuf(pb, "false");
588:    return sprintbuf(pb, "%" PRId64, jso->o.c_int64);
856:    sprintbuf(pb, "\"");
858:    sprintbuf(pb, "\"");
975:    sprintbuf(pb, "[");
977:            sprintbuf(pb, "\n");
983:                    sprintbuf(pb, ",");
985:                            sprintbuf(pb, "\n");
989:                    sprintbuf(pb, " ");
993:                    sprintbuf(pb, "null");
1001:                   sprintbuf(pb, "\n");
1006:           return sprintbuf(pb, " ]");
1007:   return sprintbuf(pb, "]");
```

I've omitted `tests/` and `printbuf.[ch]` in this output.

Thus it's a lot of overhead to initialize a variadic list, attempt a write to a stack buffer, dynamically allocate a heap buffer if it isn't big enough etc. for every string write to a `printbuf`. This is especially so in the case of single character writes such as those for `{`, `}`, `[`, `]`.

Incidentally, this function appears to be an adaptation of a function described here: https://wavepackage.wordpress.com/tag/vsnprintf/

Which notes:

"*If you are not too concerned about performance*, this solution suits well gives you a comfortable way of manipulating strings." (sic)

Anyway my changes are pretty straightforward. Since the variadic part of `sprintbuf()` is only used in two places (besides tests), I removed that and just made `sprintbuf()` a wrapper around `printbuf_memappend()` that takes strlen for you. The two variadic prints have been replaced with `snprintf()`'s into static buffers that call `sprintbuf()` on the result.

This results in performance gains of about 350%, and much nicer flamegraph:

![flamegraph_good](https://cloud.githubusercontent.com/assets/6827003/22560323/2ad414d8-e942-11e6-848f-97e921cb07d3.png)

Some cursory `time` analysis backs this up.

Before:

```
~/json-c> time ./a.out
3.51user 0.00system 0:03.54elapsed 99%CPU (0avgtext+0avgdata 1920maxresident)k
0inputs+0outputs (0major+238minor)pagefaults 0swaps
~/json-c> time ./a.out
3.52user 0.00system 0:03.53elapsed 99%CPU (0avgtext+0avgdata 2012maxresident)k
0inputs+0outputs (0major+240minor)pagefaults 0swaps
~/json-c> time ./a.out
3.49user 0.00system 0:03.50elapsed 99%CPU (0avgtext+0avgdata 1932maxresident)k
0inputs+0outputs (0major+238minor)pagefaults 0swaps
```

After:

```
~/json-c> time ./a.out
0.99user 0.00system 0:01.00elapsed 99%CPU (0avgtext+0avgdata 1944maxresident)k
0inputs+0outputs (0major+237minor)pagefaults 0swaps
~/json-c> time ./a.out
1.02user 0.00system 0:01.03elapsed 99%CPU (0avgtext+0avgdata 1960maxresident)k
0inputs+0outputs (0major+240minor)pagefaults 0swaps
~/json-c> time ./a.out
1.02user 0.00system 0:01.03elapsed 99%CPU (0avgtext+0avgdata 1956maxresident)k
0inputs+0outputs (0major+238minor)pagefaults 0swaps
```

The test program I used for the flame graphs and these time results is:

```C
#include <stdio.h>
#include <json-c/json.h>

#define ITERATIONS 2

static json_object *
recursive_add_a2z (json_object *obj, unsigned int n)
{
  char key[5] = "KeyX";
  for (char i = 'A'; i < 'Z'; i++)
  {
    key[3] = i;
    if (n < ITERATIONS) {
      json_object *level = json_object_new_object();
      json_object_object_add (obj, key, recursive_add_a2z (level, n+1));
    }
    else {
      json_object *ex_string = json_object_new_string("Example");
      json_object_object_add(obj, "lol", ex_string);
      return obj;
    }
  }
  return obj;
}

int main (int argc, char *argv[])
{
  json_object *root = json_object_new_object();
  recursive_add_a2z (root, 0);
  for (int i = 0; i < 10000; i++)
  {
    json_object_to_json_string (root);
  }
}
```

For the flame graphs, the `for()` loop in main was changed to an infinite `while()` and allowed to run under `perf` for ~15 seconds.

I also removed the unit test for `sprintbuf()` since the tests for `printbuf_memappend()` now cover its functionality.
