### PR TITLE
Fix error C3688 when compiling on Visual Studio 2015

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -590,7 +590,7 @@ static int json_object_int_to_json_string(struct json_object* jso,
 {
 	/* room for 19 digits, the sign char, and a null term */
 	static char sbuf[21];
-	snprintf(sbuf, sizeof(sbuf), "%"PRId64, jso->o.c_int64);
+	snprintf(sbuf, sizeof(sbuf), "%" PRId64, jso->o.c_int64);
 	return printbuf_memappend (pb, sbuf, strlen(sbuf));
 }
 


### PR DESCRIPTION
If compiled on VS2015 with the default configuration, the original codebase raises error C3688: invalid literal suffix 'PRId64'; literal operator or literal operator template 'operator ""PRId64' not found. Simply adding a space before PRId64 resolves this issue.