### PR TITLE
Fix stack buffer overflow in json_object_double_to_json_string_format()

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -717,6 +717,8 @@ static int json_object_double_to_json_string_format(struct json_object* jso,
         format ? format : 
           (modf(jso->o.c_double, &dummy) == 0) ? "%.17g.0" : "%.17g",
           jso->o.c_double);
+  if(size < 0 || size >= (int)sizeof(buf))
+    size = (int)sizeof(buf);
 
   p = strchr(buf, ',');
   if (p) {


### PR DESCRIPTION
Issue originally found in the json-c 0.11 internal copy in GDAL but also found
in latest git version.

If doing things like
```
json_object* obj = json_object_new_double(1e300);
json_object_set_serializer(obj, json_object_double_to_json_string, "%f", NULL);
json_object_to_json_string(obj)
```

```
    size = snprintf(buf, sizeof(buf),
        format ? format :
          (modf(jso->o.c_double, &dummy) == 0) ? "%.17g.0" : "%.17g",
          jso->o.c_double);
```
will return a value greater than 128 since at least 300 characters are needed.
This value is then passed to printbuf_memappend(pb, buf, size); that tries to
read size bytes in buf.

So we should clamp size to sizeof(buf). And on Windows, _snprintf() returns -1
in that situation, so deal also with this case.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1682
Credit to OSS-Fuzz