### PR TITLE
build,cmake: build,cmake: rename libjson-c-static.a to libjson-c.a

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,5 +105,5 @@
 /CMakeFiles
 /cmake_install.cmake
 /include
-/libjson-c-static.a
+/libjson-c.a
 /libjson-c.so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(json-c-static
 )
 
 set_property(TARGET json-c PROPERTY C_STANDARD 99)
+set_property(TARGET json-c-static PROPERTY C_STANDARD 99)
 set_target_properties(json-c-static PROPERTIES OUTPUT_NAME json-c)
 
 install(TARGETS json-c json-c-static

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(json-c-static
 )
 
 set_property(TARGET json-c PROPERTY C_STANDARD 99)
+set_target_properties(json-c-static PROPERTIES OUTPUT_NAME json-c)
 
 install(TARGETS json-c json-c-static
     RUNTIME DESTINATION bin


### PR DESCRIPTION
Based on this comment (https://github.com/json-c/json-c/pull/321#issuecomment-309446230) , I decided to check if it is possible to have both libjson-c.a and libjson-c.so.
Seems it is.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>