### PR TITLE
tests: fix tests in travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ os:
 before_install:
   - echo $LANG
   - echo $LC_ALL
+  - set -e
 
 install:
   - sh autogen.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ script:
 
 after_success:
   - make check
-  - cppcheck --quiet *.h *.c tests/
+  - if type cppcheck &> /dev/null ; then cppcheck --error-exitcode=1 --quiet *.h *.c tests/ ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - sh autogen.sh
 
 before_script:
-  - ./configure
+  - ./configure --enable-strerror-override
 
 script:
   - make

--- a/Makefile.am
+++ b/Makefile.am
@@ -53,6 +53,12 @@ libjson_c_la_SOURCES = \
 	printbuf.c \
 	random_seed.c
 
+if ENABLE_STRERROR_OVERRIDE
+libjson_cinclude_HEADERS+= \
+	strerror_override.h
+libjson_c_la_SOURCES+= \
+	strerror_override.c
+endif
 
 distclean-local:
 	-rm -rf $(testsubdir)

--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,22 @@ else
   AC_MSG_RESULT([RDRAND Hardware RNG Hash Seed disabled. Use --enable-rdrand to enable])
 fi
 
+AC_ARG_ENABLE(strerror-override,
+ AS_HELP_STRING([--enable-strerror-override],
+   [Override strerror() function with internal version.]),
+[if test x$enableval = xyes; then
+  enable_strerror_override=yes
+  AC_DEFINE(ENABLE_STRERROR_OVERRIDE, 1, [Override strerror() with internal version])
+fi])
+
+AM_CONDITIONAL([ENABLE_STRERROR_OVERRIDE], [test "x$enable_strerror_override" = "xyes"])
+
+if test "x$enable_strerror_override" = "xyes"; then
+  AC_MSG_RESULT([Overriding `strerror()` function with internal version])
+else
+  AC_MSG_RESULT([Using libc's `strerror()` function])
+fi
+
 # enable silent build by default
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,8 @@ AM_INIT_AUTOMAKE
 
 AC_PROG_MAKE_SET
 
+AC_CANONICAL_HOST
+
 AC_ARG_ENABLE(rdrand,
  AS_HELP_STRING([--enable-rdrand],
    [Enable RDRAND Hardware RNG Hash Seed generation on supported x86/x64 platforms.]),
@@ -57,13 +59,21 @@ AS_IF([test "x$ac_cv___thread" != xno],
 AC_FUNC_VPRINTF
 AC_FUNC_MEMCMP
 AC_CHECK_FUNCS([realloc])
-AC_CHECK_FUNCS(strcasecmp strdup strerror snprintf vsnprintf vasprintf open vsyslog strncasecmp setlocale uselocale)
+AC_CHECK_FUNCS(strcasecmp strdup strerror snprintf vsnprintf vasprintf open vsyslog strncasecmp setlocale)
 AC_CHECK_DECLS([INFINITY], [], [], [[#include <math.h>]])
 AC_CHECK_DECLS([nan], [], [], [[#include <math.h>]])
 AC_CHECK_DECLS([isnan], [], [], [[#include <math.h>]])
 AC_CHECK_DECLS([isinf], [], [], [[#include <math.h>]])
 AC_CHECK_DECLS([_isnan], [], [], [[#include <float.h>]])
 AC_CHECK_DECLS([_finite], [], [], [[#include <float.h>]])
+
+case "${host_os}" in
+	linux*)
+		AC_CHECK_FUNCS([uselocale])
+		;;
+	*)	# Nothing
+		;;
+esac
 
 if test "$ac_cv_have_decl_isnan" = "yes" ; then
    AC_TRY_LINK([#include <math.h>], [float f = 0.0; return isnan(f)], [], [LIBS="$LIBS -lm"])

--- a/json_object.c
+++ b/json_object.c
@@ -12,13 +12,14 @@
 
 #include "config.h"
 
+#include "strerror_override.h"
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>
 #include <string.h>
 #include <math.h>
-#include <errno.h>
 
 #include "debug.h"
 #include "printbuf.h"

--- a/json_pointer.c
+++ b/json_pointer.c
@@ -8,10 +8,11 @@
 
 #include "config.h"
 
+#include "strerror_override.h"
+
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <errno.h>
 #include <string.h>
 #include <ctype.h>
 

--- a/json_util.c
+++ b/json_util.c
@@ -12,13 +12,14 @@
 #include "config.h"
 #undef realloc
 
+#include "strerror_override.h"
+
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>
 #include <limits.h>
 #include <string.h>
-#include <errno.h>
 #include <ctype.h>
 
 #ifdef HAVE_SYS_TYPES_H

--- a/random_seed.c
+++ b/random_seed.c
@@ -9,6 +9,7 @@
  *
  */
 
+#include "strerror_override.h"
 #include <stdio.h>
 #include "config.h"
 #include "random_seed.h"
@@ -128,7 +129,6 @@ retry:
 #include <string.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <errno.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 

--- a/strerror_override.c
+++ b/strerror_override.c
@@ -1,4 +1,4 @@
-#include <errno.h>
+#include "strerror_override.h"
 
 /*
  * Override strerror() to get consistent output across platforms.
@@ -54,7 +54,7 @@ static struct {
 
 #define PREFIX "ERRNO="
 static char errno_buf[128] = PREFIX;
-char *strerror(int errno_in)
+char *_json_c_strerror(int errno_in)
 {
 	int start_idx;
 	char digbuf[20];

--- a/strerror_override.h
+++ b/strerror_override.h
@@ -1,0 +1,12 @@
+#ifndef __STRERROR_OVERRIDE_H__
+#define __STRERROR_OVERRIDE_H__
+
+#include "config.h"
+#include <errno.h>
+
+#if ENABLE_STRERROR_OVERRIDE
+char *_json_c_strerror(int errno_in);
+#define strerror	_json_c_strerror
+#endif
+
+#endif /* __STRERROR_OVERRIDE_H__ */ 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -52,7 +52,7 @@ EXTRA_DIST+= test2Formatted_plain.expected
 EXTRA_DIST+= test2Formatted_pretty.expected
 EXTRA_DIST+= test2Formatted_spaced.expected
 
-test_util_file_SOURCES = test_util_file.c strerror_override.c
+test_util_file_SOURCES = test_util_file.c
 
 testsubdir=testSubDir
 TESTS_ENVIRONMENT       = top_builddir=$(top_builddir)

--- a/tests/test_basic.test
+++ b/tests/test_basic.test
@@ -11,5 +11,9 @@ fi
 filename=$(basename "$0")
 filename="${filename%.*}"
 
-run_output_test $filename
+# This is only for the test_util_file.test ;
+# more stuff could be extended
+cp -f "$srcdir/valid.json" .
+
+run_output_test $filename "$srcdir"
 exit $?

--- a/tests/test_json_pointer.c
+++ b/tests/test_json_pointer.c
@@ -1,4 +1,4 @@
-#include <errno.h>
+#include "strerror_override.h"
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>

--- a/tests/test_util_file.c
+++ b/tests/test_util_file.c
@@ -1,4 +1,4 @@
-#include <errno.h>
+#include "strerror_override.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>

--- a/tests/test_util_file.c
+++ b/tests/test_util_file.c
@@ -106,6 +106,7 @@ static void stat_and_cat(const char *file)
 	buf[sb.st_size] = '\0';
 	printf("file[%s], size=%d, contents=%s\n", file, (int)sb.st_size, buf);
 	free(buf);
+	close(d);
 }
 
 int main(int argc, char **argv)

--- a/tests/test_util_file.test
+++ b/tests/test_util_file.test
@@ -1,15 +1,1 @@
-#!/bin/sh
-
-# Common definitions
-if test -z "$srcdir"; then
-    srcdir="${0%/*}"
-    test "$srcdir" = "$0" && srcdir=.
-    test -z "$srcdir" && srcdir=.
-fi
-. "$srcdir/test-defs.sh"
-
-cp -f "$srcdir/valid.json" .
-run_output_test test_util_file "$srcdir"
-_err=$?
-
-exit $_err
+test_basic.test


### PR DESCRIPTION
Seems some failing tests have piled up, due to a missing `set -e`

* `test_util_file` test ; the issue is that Apple linkers don't allow to override `strerror` and this seems to be locked down on travis-ci.org [ for security reasons I assume ] ; I tried some solutions from the web (like here: http://tlrobinson.net/blog/2007/12/overriding-library-functions-in-mac-os-x-the-easy-way-dyld_insert_libraries/) ; patches can be checked out here: https://github.com/commodo/json-c/commit/49ed91eb39d96ac625553843ba2c02018f601964  & https://github.com/commodo/json-c/commit/ca13901e0c37a9885fbc665c638185f0ef1c804f  ; so, trying to force the test's `strerror`  did not work for me ; they worked locally, but not on travis ;  I gave up [ after a few hours ] and resumed to go by checking specific output only for Darwin
* `test_locale` : not sure if the fix is sane ; seems that `setlocale()` actually changes the locale on Apple, while the `uselocale()` function does not ; 

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>