### PR TITLE
strerror_override: add extern "C" and JSON_EXPORT specifiers for Visual C++ compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - sh autogen.sh
 
 before_script:
-  - ./configure --enable-strerror-override
+  - ./configure
 
 script:
   - make

--- a/strerror_override.h
+++ b/strerror_override.h
@@ -4,10 +4,20 @@
 #include "config.h"
 #include <errno.h>
 
-char *_json_c_strerror(int errno_in);
+#include "json_object.h" /* for JSON_EXPORT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JSON_EXPORT char *_json_c_strerror(int errno_in);
 
 #ifndef STRERROR_OVERRIDE_IMPL
 #define strerror	_json_c_strerror
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* _json_strerror_override_h_ */ 


### PR DESCRIPTION
Fixes build on AppVeyor.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>