### PR TITLE
Fix make dist and make distcheck

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,8 @@ libjson_cinclude_HEADERS = \
 	strdup_compat.h \
 	vasprintf_compat.h \
 	printbuf.h \
-	random_seed.h
+	random_seed.h \
+	strerror_override.h
 
 libjson_c_la_LDFLAGS = -version-info 3:0:0 -no-undefined @JSON_BSYMBOLIC_LDFLAGS@
 
@@ -52,7 +53,8 @@ libjson_c_la_SOURCES = \
 	linkhash.c \
 	printbuf.c \
 	random_seed.c \
-	strerror_override.c
+	strerror_override.c \
+	strerror_override_private.h
 
 distclean-local:
 	-rm -rf $(testsubdir)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 EXTRA_DIST = README.md README.html README-WIN32.html 
 EXTRA_DIST += config.h.win32 json-c.vcproj json-c.vcxproj json-c.vcxproj.filters
-EXTRA_DIST += Doxyfile doc
+EXTRA_DIST += Doxyfile
 
 dist-hook:
 	test -d "$(distdir)/doc" || mkdir "$(distdir)/doc"


### PR DESCRIPTION
`EXTRA_DIST` copies the listed directories/files from the **source** directory into the distribution.

Since the `doc` directory does not exist after running autogen + configure + make dist, the distribution tarball generation fails. Note that the `dist-hook` rule below operates on `distdir`, not on the source directory where `EXTRA_DIST` expects the existence of the `doc` folder.

In summary, even if I remove `doc` from `EXTRA_DIST`, the dist tarball will always contain the documentation (due to the `dist-hook` rule).