### PR TITLE
Clamp double to int32 when narrowing in json_object_get_int.

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -635,6 +635,10 @@ int32_t json_object_get_int(const struct json_object *jso)
 		return INT32_MAX;
 	return (int32_t) cint64;
   case json_type_double:
+    if (jso->o.c_double <= INT32_MIN)
+      return INT32_MIN;
+    if (jso->o.c_double >= INT32_MAX)
+      return INT32_MAX;
     return (int32_t)jso->o.c_double;
   case json_type_boolean:
     return jso->o.c_boolean;


### PR DESCRIPTION
Avoids undefined behavior.  Found by autofuzz.