### PR TITLE
1.make it can been compiled with Visual Studio 2010 by modify the CMakeList.txt and others

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,8 @@ set(JSON_C_HEADERS
     ./linkhash.h
     ./math_compat.h
     ./strdup_compat.h
+	./strerror_override.h
+	./strerror_override_private
     ./vasprintf_compat.h
     ./printbuf.h
     ./random_seed.h
@@ -66,6 +68,7 @@ set(JSON_C_SOURCES
     ./json_util.c
     ./linkhash.c
     ./printbuf.c
+	./strerror_override.c
     ./random_seed.c
 )
 

--- a/arraylist.c
+++ b/arraylist.c
@@ -62,7 +62,7 @@ array_list_free(struct array_list *arr)
 }
 
 void*
-array_list_get_idx(struct array_list *arr, size_t i)
+array_list_get(struct array_list *arr, size_t i)
 {
   if(i >= arr->length) return NULL;
   return arr->array[i];
@@ -92,7 +92,7 @@ static int array_list_expand_internal(struct array_list *arr, size_t max)
 }
 
 int
-array_list_put_idx(struct array_list *arr, size_t idx, void *data)
+array_list_insert(struct array_list *arr, size_t idx, void *data)
 {
   if (idx > SIZE_T_MAX - 1 ) return -1;
   if(array_list_expand_internal(arr, idx+1)) return -1;
@@ -106,7 +106,7 @@ array_list_put_idx(struct array_list *arr, size_t idx, void *data)
 int
 array_list_add(struct array_list *arr, void *data)
 {
-  return array_list_put_idx(arr, arr->length, data);
+  return array_list_insert(arr, arr->length, data);
 }
 
 void

--- a/arraylist.h
+++ b/arraylist.h
@@ -35,10 +35,10 @@ extern void
 array_list_free(struct array_list *al);
 
 extern void*
-array_list_get_idx(struct array_list *al, size_t i);
+array_list_get(struct array_list *al, size_t i);
 
 extern int
-array_list_put_idx(struct array_list *al, size_t i, void *data);
+array_list_insert(struct array_list *al, size_t i, void *data);
 
 extern int
 array_list_add(struct array_list *al, void *data);

--- a/json_object.h
+++ b/json_object.h
@@ -182,7 +182,7 @@ typedef enum json_type {
  *
  * @param obj the json_object instance
  */
-JSON_EXPORT struct json_object* json_object_get(struct json_object *obj);
+JSON_EXPORT struct json_object* json_object_retain(struct json_object *obj);
 
 /**
  * Decrement the reference count of json_object and free if it reaches zero.
@@ -192,7 +192,7 @@ JSON_EXPORT struct json_object* json_object_get(struct json_object *obj);
  * @param obj the json_object instance
  * @returns 1 if the object was freed.
  */
-JSON_EXPORT int json_object_put(struct json_object *obj);
+JSON_EXPORT int json_object_release(struct json_object *obj);
 
 /**
  * Check if the json_object is of a given type

--- a/json_pointer.c
+++ b/json_pointer.c
@@ -240,7 +240,7 @@ int json_pointer_set(struct json_object **obj, const char *path, struct json_obj
 	}
 
 	if (path[0] == '\0') {
-		json_object_put(*obj);
+		json_object_release(*obj);
 		*obj = value;
 		return 0;
 	}
@@ -294,7 +294,7 @@ int json_pointer_setf(struct json_object **obj, struct json_object *value, const
 		return rc;
 
 	if (path_copy[0] == '\0') {
-		json_object_put(*obj);
+		json_object_release(*obj);
 		*obj = value;
 		goto out;
 	}

--- a/json_tokener.c
+++ b/json_tokener.c
@@ -139,7 +139,7 @@ static void json_tokener_reset_level(struct json_tokener *tok, int depth)
 {
   tok->stack[depth].state = json_tokener_state_eatws;
   tok->stack[depth].saved_state = json_tokener_state_start;
-  json_object_put(tok->stack[depth].current);
+  json_object_release(tok->stack[depth].current);
   tok->stack[depth].current = NULL;
   free(tok->stack[depth].obj_field_name);
   tok->stack[depth].obj_field_name = NULL;
@@ -178,7 +178,7 @@ struct json_object* json_tokener_parse_verbose(const char *str,
     *error = tok->err;
     if(tok->err != json_tokener_success) {
 		if (obj != NULL)
-			json_object_put(obj);
+			json_object_release(obj);
         obj = NULL;
     }
 
@@ -378,7 +378,7 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
 
     case json_tokener_state_finish:
       if(tok->depth == 0) goto out;
-      obj = json_object_get(current);
+      obj = json_object_retain(current);
       json_tokener_reset_level(tok, tok->depth);
       tok->depth--;
       goto redo_char;
@@ -387,10 +387,11 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
       {
 	size_t size_inf;
 	int is_negative = 0;
+	char *infbuf;
 
 	printbuf_memappend_fast(tok->pb, &c, 1);
 	size_inf = json_min(tok->st_pos+1, json_inf_str_len);
-	char *infbuf = tok->pb->buf;
+	infbuf = tok->pb->buf;
 	if (*infbuf == '-')
 	{
 		infbuf++;
@@ -958,7 +959,7 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
 
   if (tok->err == json_tokener_success)
   {
-    json_object *ret = json_object_get(current);
+    json_object *ret = json_object_retain(current);
 	int ii;
 
 	/* Partially reset, so we parse additional objects on subsequent calls. */

--- a/linkhash.c
+++ b/linkhash.c
@@ -560,6 +560,11 @@ int lh_table_resize(struct lh_table *t, int new_size)
 	return 0;
 }
 
+unsigned long lh_get_hash(const struct lh_table *t, const void *k)
+{
+	return t->hash_fn(k);
+}
+
 void lh_table_free(struct lh_table *t)
 {
 	struct lh_entry *c;

--- a/linkhash.h
+++ b/linkhash.h
@@ -332,10 +332,7 @@ int lh_table_resize(struct lh_table *t, int new_size);
  * @param k a pointer to the key to lookup
  * @return the key's hash
  */
-static inline unsigned long lh_get_hash(const struct lh_table *t, const void *k)
-{
-	return t->hash_fn(k);
-}
+unsigned long lh_get_hash(const struct lh_table *t, const void *k);
 
 /* Don't use this outside of linkhash.h: */
 #ifdef __UNCONST

--- a/random_seed.c
+++ b/random_seed.c
@@ -186,10 +186,10 @@ static int get_dev_random_seed()
 
 static int get_cryptgenrandom_seed()
 {
-    DEBUG_SEED("get_cryptgenrandom_seed");
-
     HCRYPTPROV hProvider = 0;
     int r;
+
+    DEBUG_SEED("get_cryptgenrandom_seed");
 
     if (!CryptAcquireContextW(&hProvider, 0, 0, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT | CRYPT_SILENT)) {
         fprintf(stderr, "error CryptAcquireContextW");


### PR DESCRIPTION
2.replace json_object_get/put API with json_object_retain/release, as they operate the reference counter, and confused with array_list_get/put_idx.
3.replace array_list_get/put_idx API with array_list_get/insert to make them more clear to use.
4.removed the lh_get_hash static decoration.