### PR TITLE
Use strtoll() to parse ints

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -173,6 +173,7 @@ AX_COMPILE_CHECK_SIZEOF(int)
 AX_COMPILE_CHECK_SIZEOF(long)
 AX_COMPILE_CHECK_SIZEOF(long long)
 AX_COMPILE_CHECK_SIZEOF(size_t, [#include <stdint.h>])
+AX_COMPILE_CHECK_SIZEOF(int64_t, [#include <stdint.h>])
 
 AC_CONFIG_FILES([
 Makefile

--- a/json_object.c
+++ b/json_object.c
@@ -33,6 +33,10 @@
 #include "strdup_compat.h"
 #include "snprintf_compat.h"
 
+#if SIZEOF_LONG_LONG != SIZEOF_INT64_T
+#error "The long long type isn't 64-bits"
+#endif
+
 // Don't define this.  It's not thread-safe.
 /* #define REFCOUNT_DEBUG 1 */
 


### PR DESCRIPTION
Instead of using `sscanf()` (whose behavior is surprisingly underspecified) to parse integer values, use `strtoll()` instead.  It turns out to be much simpler, and hopefully is more portable.