### PR TITLE
Fix double to int cast overflow in json_object_get_int64.

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -688,6 +688,10 @@ int64_t json_object_get_int64(const struct json_object *jso)
 	case json_type_int:
 		return jso->o.c_int64;
 	case json_type_double:
+		if (jso->o.c_double >= INT64_MAX)
+			return INT64_MAX;
+		if (jso->o.c_double <= INT64_MIN)
+			return INT64_MIN;
 		return (int64_t)jso->o.c_double;
 	case json_type_boolean:
 		return jso->o.c_boolean;


### PR DESCRIPTION
Found with autofuzz in GDAL