### PR TITLE
Fix a compiler warning.

### DIFF
--- a/json_object.h
+++ b/json_object.h
@@ -977,7 +977,7 @@ JSON_EXPORT int json_object_equal(struct json_object *obj1,
  *
  * @return On success 1 or 2, -1 on errors
  */
-typedef int (json_c_shallow_copy_fn)(json_object *src, json_object *parent, const char *key, size_t index, json_object **dst);
+typedef int (*json_c_shallow_copy_fn)(json_object *src, json_object *parent, const char *key, size_t index, json_object **dst);
 
 /**
  * The default shallow copy implementation for use with json_object_deep_copy().
@@ -991,7 +991,7 @@ typedef int (json_c_shallow_copy_fn)(json_object *src, json_object *parent, cons
  *
  * @return 1 on success, -1 on errors, but never 2.
  */
-json_c_shallow_copy_fn json_c_shallow_copy_default;
+int json_c_shallow_copy_default(json_object *src, json_object *parent, const char *key, size_t index, json_object **dst);
 
 /**
  * Copy the contents of the JSON object.

--- a/tests/test_deep_copy.c
+++ b/tests/test_deep_copy.c
@@ -85,7 +85,7 @@ int my_custom_serializer(struct json_object *jso, struct printbuf *pb, int level
 	return 0;
 }
 
-json_c_shallow_copy_fn my_shallow_copy;
+//json_c_shallow_copy_fn my_shallow_copy;
 int my_shallow_copy(json_object *src, json_object *parent, const char *key, size_t index, json_object **dst)
 {
 	int rc;


### PR DESCRIPTION
In VS 2015, the warning text is "warning C4550: expression evaluates to a function which is missing an argument list".