### PR TITLE
Fix a VS 2015 compiler warning.

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -1374,7 +1374,7 @@ int json_c_shallow_copy_default(json_object *src, json_object *parent, const cha
  *
  * Note: caller is responsible for freeing *dst if this fails and returns -1.
  */
-static int json_object_deep_copy_recursive(struct json_object *src, struct json_object *parent, const char *key_in_parent, size_t index_in_parent, struct json_object **dst, json_c_shallow_copy_fn shallow_copy)
+static int json_object_deep_copy_recursive(struct json_object *src, struct json_object *parent, const char *key_in_parent, size_t index_in_parent, struct json_object **dst, json_c_shallow_copy_fn *shallow_copy)
 {
 	struct json_object_iter iter;
 	size_t src_array_len, ii;
@@ -1443,7 +1443,7 @@ static int json_object_deep_copy_recursive(struct json_object *src, struct json_
 	return 0;
 }
 
-int json_object_deep_copy(struct json_object *src, struct json_object **dst, json_c_shallow_copy_fn shallow_copy)
+int json_object_deep_copy(struct json_object *src, struct json_object **dst, json_c_shallow_copy_fn *shallow_copy)
 {
 	int rc;
 

--- a/json_object.h
+++ b/json_object.h
@@ -1009,7 +1009,7 @@ json_c_shallow_copy_fn json_c_shallow_copy_default;
  *          or if the destination pointer is non-NULL
  */
 
-JSON_EXPORT int json_object_deep_copy(struct json_object *src, struct json_object **dst, json_c_shallow_copy_fn shallow_copy); 
+JSON_EXPORT int json_object_deep_copy(struct json_object *src, struct json_object **dst, json_c_shallow_copy_fn *shallow_copy); 
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
In VS 2015, the warning text is "warning C4550: expression evaluates to a function which is missing an argument list".
