### PR TITLE
Makefile: Add ACLOCAL_AMFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+ACLOCAL_AMFLAGS = -I autoconf-archive/m4
+
 EXTRA_DIST = README.md README.html
 EXTRA_DIST += config.h.win32
 EXTRA_DIST += Doxyfile


### PR DESCRIPTION
This is recommended by the [libtool manual](https://www.gnu.org/software/libtool/manual/html_node/Invoking-libtoolize.html).

```
In the future other Autotools will automatically check the contents of
AC_CONFIG_MACRO_DIRS, but at the moment it is more portable to add the
macro directory to ACLOCAL_AMFLAGS in Makefile.am, which is where the
tools currently look. If libtoolize doesn’t see AC_CONFIG_MACRO_DIRS,
it too will honour the first ‘-I’ argument in ACLOCAL_AMFLAGS when
choosing a directory to store libtool configuration macros in.  It is
perfectly sensible to use both AC_CONFIG_MACRO_DIRS and ACLOCAL_AMFLAGS,
as long as they are kept in synchronisation.
```