### PR TITLE
doc: Use other doxygen feature to specify mainpage

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -753,8 +753,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = README.md \
-                         .
+INPUT                  = 
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -891,7 +890,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-`json-c`                       {#mainpage}
+`json-c`
 ========
 
 1. [Overview and Build Status](#overview)


### PR DESCRIPTION
Previously a special tag was added to README.md to make this the
main page in Doxygen generated docs. When viewing the README on the
GitHub page this tag was not hidden.

After upgrading to Doxygen 1.8.8 (and above) in changeset
219025727dd7d981cf2fea7f2095570924e7bae7 a new Doxygen feature can be
used to specify the main page: Since release 1.8.3 Doxygen has a special
option to set a markdown file as main page. When using this option we
can drop the tag, making the README rendered by GitHub nice to look at.

Fixes: ae66b243690871f2daea5ae4b2a4669081d7c556