### PR TITLE
json_object: Add size_t json_object_sizeof()

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -509,6 +509,11 @@ int json_object_object_length(const struct json_object *jso)
 	return lh_table_length(jso->o.c_object);
 }
 
+size_t json_object_sizeof(void)
+{
+	return sizeof(struct json_object);
+}
+
 struct json_object* json_object_object_get(const struct json_object* jso,
 					   const char *key)
 {

--- a/json_object.h
+++ b/json_object.h
@@ -392,6 +392,11 @@ JSON_EXPORT struct lh_table* json_object_get_object(const struct json_object *ob
  */
 JSON_EXPORT int json_object_object_length(const struct json_object* obj);
 
+/** Get the sizeof (struct json_object).
+ * @returns a size_t with the sizeof (struct json_object)
+ */
+JSON_EXPORT size_t json_object_sizeof(void);
+
 /** Add an object field to a json_object of type json_type_object
  *
  * The reference count will *not* be incremented. This is to make adding


### PR DESCRIPTION
This comes in handy when one wants to pre-allocate memory to store a bunch of `struct json_object`, like [gdal does](https://github.com/OSGeo/gdal/blob/f8c279b1c1ae1da1b5025e2a43a1b4d99acf2852/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonreader.cpp#L45).