### PR TITLE
json_object: Avoid double free (and thus a segfault) when ref_count gets < 0

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -182,6 +182,11 @@ int json_object_put(struct json_object *jso)
 {
 	if(!jso) return 0;
 
+	/* Avoid invalid free and crash explicitly instead of (silently)
+	 * segfaulting.
+	 */
+	assert(jso->_ref_count > 0);
+
 #if defined(HAVE_ATOMIC_BUILTINS) && defined(ENABLE_THREADING)
 	/* Note: this only allow the refcount to remain correct
 	 * when multiple threads are adjusting it.  It is still an error 


### PR DESCRIPTION
Without this patch `libu2f-server` and `sway` may segfault during regular code execution.