### PR TITLE
Fix non-GNUC define for JSON_C_CONST_FUNCTION

### DIFF
--- a/json_object.h
+++ b/json_object.h
@@ -30,7 +30,7 @@
 #ifdef __GNUC__
 #define JSON_C_CONST_FUNCTION(func) func __attribute__((const))
 #else
-#define CONST_FUNCTION(func) func
+#define JSON_C_CONST_FUNCTION(func) func
 #endif
 
 #if defined(_MSC_VER) 


### PR DESCRIPTION
Fixes a couple of compilation warnings with Visual Studio (I think, I haven't been able to test it).