### PR TITLE
json_object: Avoid invalid free (and thus a segfault) when ref_count gets < 0

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+ACLOCAL_AMFLAGS = -I autoconf-archive/m4
+
 EXTRA_DIST = README.md README.html
 EXTRA_DIST += config.h.win32
 EXTRA_DIST += Doxyfile

--- a/json_object.c
+++ b/json_object.c
@@ -182,6 +182,11 @@ int json_object_put(struct json_object *jso)
 {
 	if(!jso) return 0;
 
+	/* Avoid invalid free and crash explicitly instead of (silently)
+	 * segfaulting.
+	 */
+	assert(jso->_ref_count > 0);
+
 #if defined(HAVE_ATOMIC_BUILTINS) && defined(ENABLE_THREADING)
 	/* Note: this only allow the refcount to remain correct
 	 * when multiple threads are adjusting it.  It is still an error 


### PR DESCRIPTION
Cherry picked from master.