### PR TITLE
json_object_private: Use unsigned 32-bit integer type for refcount

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -169,6 +169,9 @@ extern struct json_object* json_object_get(struct json_object *jso)
 {
 	if (!jso) return jso;
 
+	// Don't overflow the refcounter.
+	assert(jso->_ref_count < UINT_FAST32_MAX);
+
 #if defined(HAVE_ATOMIC_BUILTINS) && defined(ENABLE_THREADING)
 	__sync_add_and_fetch(&jso->_ref_count, 1);
 #else

--- a/json_object_private.h
+++ b/json_object_private.h
@@ -29,7 +29,7 @@ struct json_object
   enum json_type o_type;
   json_object_private_delete_fn *_delete;
   json_object_to_json_string_fn *_to_json_string;
-  int _ref_count;
+  uint_fast32_t _ref_count;
   struct printbuf *_pb;
   union data {
     json_bool c_boolean;


### PR DESCRIPTION
Since https://github.com/json-c/json-c/commit/9aca3b6a087a396a81d7e26f4557eb97fecc1386 it is very, very unlikely the refcount can ever go < 0.  And as `struct json_object` is an opaque pointer for the user, there are no breaks in the API / ABI.

I choose the `uint_fast` version intentionally, so there is a guarantee for getting at least 32-bit of width, but it might be wider if the underlying architecture can handle it faster than a pure uint32_t.  An unsigned 32-bit wide integer type can handle numbers up to about 4.29 billion, so overflowing the refcounter should be very unlikely, too; the assert is simply just to prevent the caller to do something really jackass.