### PR TITLE
Resolve windows name conflict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,9 @@ add_library(json-c-static
 
 set_property(TARGET json-c PROPERTY C_STANDARD 99)
 set_property(TARGET json-c-static PROPERTY C_STANDARD 99)
+if (NOT MSVC)
 set_target_properties(json-c-static PROPERTIES OUTPUT_NAME json-c)
+endif()
 
 install(TARGETS json-c json-c-static
     RUNTIME DESTINATION bin


### PR DESCRIPTION
1. The windows dll will output the lib and dll, and rename the static
    lib will have conflict on windows.
2. Delete rename code to dismiss the conflict.