### PR TITLE
Added new_null() function

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -1030,6 +1030,12 @@ struct json_object* json_object_new_string(const char *s)
 	return jso;
 }
 
+struct json_object* json_object_new_null()
+{
+         const char *s=null;
+         return json_object_new_string(s);
+}
+
 struct json_object* json_object_new_string_len(const char *s, int len)
 {
 	char *dstbuf;


### PR DESCRIPTION
There is no json_object_new_null() #226

I added a functon in json_object.c to create object null. Please check and tell me if it requires changes. Please excuse any mistakes since this is my first major contribution in github.