### PR TITLE
cmake: Bump required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.1)
 cmake_policy(SET CMP0048 NEW)
 project(json-c VERSION 0.13.99)
 


### PR DESCRIPTION
Using 'project(foo VERSION 1.0)' requires CMake 3.0, the VERSION option
is not part of CMake 2.8.7, see:

* https://cmake.org/cmake/help/v2.8.7/cmake.html#command:project
* https://cmake.org/cmake/help/v3.0/release/3.0.0.html#commands

The property C_STANDARD was introduced with CMake 3.1, see:

* https://cmake.org/cmake/help/v3.1/release/3.1.0.html#properties

Signed-off-by: Alexander Dahl <post@lespocky.de>