### PR TITLE
Improve pkgconfig setting

### DIFF
--- a/json-c.pc.in
+++ b/json-c.pc.in
@@ -9,4 +9,4 @@ Version: @VERSION@
 Requires:
 Libs.private: @LIBS@
 Libs: -L${libdir} -ljson-c
-Cflags: -I${includedir}/json-c
+Cflags: -I${includedir} -I${includedir}/json-c


### PR DESCRIPTION
This changes allows to use #include <json-c/json.h>
instead of just #include <json.h>

This is normally possible but in some tricky case
this usage is broken without this change.

Here is the case that I encountered. I had to
compile json-c fresh version for some investigations
on newer versions. Then I installed it on my local
environment using option --prefix. After that I
had 2 versions:

 - the system wide version in usual locations
   /usr/lib and /usr/include
 - mine in my HOME directory

Then, as I'm used to include <json-c/json.h>, the
included iheder's version was the system wide one
whereas the linked lib was mine.

Signed-off-by: Jose Bollo <jose.bollo@iot.bzh>