### PR TITLE
fix c flag loss during cmake building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ configure_package_config_file(
 if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections")
     # There's a catch here.
-    set(CMAKE_C_FLAGS           "-Werror")
+    set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} -Werror")
 
     add_definitions(-D_GNU_SOURCE)
 elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")


### PR DESCRIPTION
current CMAKE_C_FLAGS will be overwrite to "-Werror", and original c flags are lost.
this will cause compile error when compile using NDK.
