### PR TITLE
Document refcount of json_tokener_parse_ex return

### DIFF
--- a/json_tokener.h
+++ b/json_tokener.h
@@ -155,9 +155,10 @@ JSON_EXPORT void json_tokener_set_flags(struct json_tokener *tok, int flags);
  * called.
  *
  * When a valid JSON value is parsed, a non-NULL json_object will be
- * returned.  Also, json_tokener_get_error() will return json_tokener_success.
- * Be sure to check the type with json_object_is_type() or
- * json_object_get_type() before using the object.
+ * returned, with a reference count of one which belongs to the caller.  Also,
+ * json_tokener_get_error() will return json_tokener_success. Be sure to check
+ * the type with json_object_is_type() or json_object_get_type() before using
+ * the object.
  *
  * @b XXX this shouldn't use internal fields:
  * Trailing characters after the parsed value do not automatically cause an


### PR DESCRIPTION
There’s no documentation which states the reference count of the object returned by `json_tokener_parse_ex`, nor who owns the reference (i.e. whether the object will be destroyed if `json_tokener_reset` is called or the tokener is destroyed). Document it, with what I believe to be the correct answer.