### PR TITLE
json_object_private: save 8 bytes in struct json_object in 64-bit arc…

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -171,7 +171,7 @@ extern struct json_object* json_object_get(struct json_object *jso)
 	if (!jso) return jso;
 
 	// Don't overflow the refcounter.
-	assert(jso->_ref_count < UINT_FAST32_MAX);
+	assert(jso->_ref_count < UINT32_MAX);
 
 #if defined(HAVE_ATOMIC_BUILTINS) && defined(ENABLE_THREADING)
 	__sync_add_and_fetch(&jso->_ref_count, 1);

--- a/json_object_private.h
+++ b/json_object_private.h
@@ -27,9 +27,9 @@ typedef void (json_object_private_delete_fn)(struct json_object *o);
 struct json_object
 {
   enum json_type o_type;
+  uint32_t _ref_count;
   json_object_private_delete_fn *_delete;
   json_object_to_json_string_fn *_to_json_string;
-  uint_fast32_t _ref_count;
   struct printbuf *_pb;
   union data {
     json_bool c_boolean;


### PR DESCRIPTION
…hitectures

- there is no need for _ref_count to be uint_fast32_t (the compiler
  might decide to use a 64-bit int). make it uint32_t instead.
- reorder the 32-bit integer fields (o_type and _ref_count) so that
  there is no wasted 4-byte gap after each of them.