### PR TITLE
README.html:fix link to Doxygen docs, remove WIN32 link

### DIFF
--- a/README.html
+++ b/README.html
@@ -8,8 +8,8 @@
 		<h2>JSON-C - A JSON implementation in C</h2>
 
 		<h3>Overview</h3>
-		<p>JSON-C implements a reference counting object model that allows you to easily 
-		construct JSON objects in C, output them as JSON formatted strings and parse 
+		<p>JSON-C implements a reference counting object model that allows you to easily
+		construct JSON objects in C, output them as JSON formatted strings and parse
 		JSON formatted strings back into the C representation of JSON objects.
 		It aims to conform to <a href="https://tools.ietf.org/html/rfc7159">RFC 7159</a>.
 		</p>
@@ -26,8 +26,7 @@
 		</ul>
 
 		<h3>Documentation</h3>
-		<P>Doxygen generated documentation exists <a href="doc/html/json__object_8h.html">here</a>
-		and Win32 specific notes can be found <a href="README-WIN32.html">here</a>.</P>
+		<P>Doxygen generated documentation exists <a href="http://json-c.github.io/json-c/">here</a>.</P>
 
 		<h3><a href="https://github.com/json-c/json-c">GIT Reposository</a></h3>
 		<p><strong><code>git clone https://github.com/json-c/json-c.git</code></strong></p>


### PR DESCRIPTION
fixes #438
[skip ci]