### PR TITLE
Fix compiler warnings

### DIFF
--- a/linkhash.h
+++ b/linkhash.h
@@ -79,6 +79,9 @@ typedef unsigned long (lh_hash_fn) (const void *k);
  */
 typedef int (lh_equal_fn) (const void *k1, const void *k2);
 
+int lh_char_equal(const void *k1, const void *k2);
+int lh_ptr_equal(const void *k1, const void *k2);
+
 /**
  * An entry in the hash table
  */

--- a/random_seed.c
+++ b/random_seed.c
@@ -16,6 +16,8 @@
 
 #define DEBUG_SEED(s)
 
+#define HAVE_RDRAND 0
+#define HAVE_CRYPTGENRANDOM 0
 
 #if defined ENABLE_RDRAND
 
@@ -136,7 +138,7 @@ retry:
 
 static const char *dev_random_file = "/dev/urandom";
 
-static int has_dev_urandom()
+static int has_dev_urandom(void)
 {
     struct stat buf;
     if (stat(dev_random_file, &buf)) {
@@ -148,7 +150,7 @@ static int has_dev_urandom()
 
 /* get_dev_random_seed */
 
-static int get_dev_random_seed()
+static int get_dev_random_seed(void)
 {
     DEBUG_SEED("get_dev_random_seed");
 
@@ -213,7 +215,7 @@ static int get_cryptgenrandom_seed()
 
 #include <time.h>
 
-static int get_time_seed()
+static int get_time_seed(void)
 {
     DEBUG_SEED("get_time_seed");
 
@@ -223,7 +225,7 @@ static int get_time_seed()
 
 /* json_c_get_random_seed */
 
-int json_c_get_random_seed()
+int json_c_get_random_seed(void)
 {
 #if HAVE_RDRAND
     if (has_rdrand()) return get_rdrand_seed();

--- a/random_seed.h
+++ b/random_seed.h
@@ -20,7 +20,7 @@
 extern "C" {
 #endif
 
-extern int json_c_get_random_seed();
+extern int json_c_get_random_seed(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Compiler complains about missing prototype and undefined macros. It turns into an error when -Werror is turned on and the compilation aborts. 