### PR TITLE
create folders with mode 0755 when building

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,8 @@ AC_PROG_MAKE_SET
 
 AC_CANONICAL_HOST
 
+MKDIR_P="mkdir -m 0755 -p"
+
 AC_ARG_ENABLE(threading,
  AS_HELP_STRING([--enable-threading],
    [Enable code to support partly multi-threaded use]),


### PR DESCRIPTION
Hi,

My user has umask `077`. When running `sudo make install`, the directories '/usr/local/include/json-c' and '/usr/local/lib/pkgconfig' are created with the corresponding permissions, which means that users of the system cannot read them afterwards.

This patch adds a setting to ensure that folders are created with the right permissions, inspired by this SO answer https://unix.stackexchange.com/a/436000. I have tested that it fixes the problem for me, i.e., the Makefile is generated with the corresponding mkdir calls, and running `sudo make install` creates the directories with the proper permissions.

(Disclaimer: I don't know anything about autotools, so I don't know if this is the right way to fix the problem (or right place to add the directive I added). Also I don't know whether this impacts portability, i.e., are there reasonable systems where `mkdir` does not support the `-m` flag?)