### PR TITLE
Add support for uint64

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -177,7 +177,7 @@ extern struct json_object* json_object_get(struct json_object *jso)
 	__sync_add_and_fetch(&jso->_ref_count, 1);
 #else
 	++jso->_ref_count;
-#endif        
+#endif
 
 	return jso;
 }
@@ -193,7 +193,7 @@ int json_object_put(struct json_object *jso)
 
 #if defined(HAVE_ATOMIC_BUILTINS) && defined(ENABLE_THREADING)
 	/* Note: this only allow the refcount to remain correct
-	 * when multiple threads are adjusting it.  It is still an error 
+	 * when multiple threads are adjusting it.  It is still an error
 	 * for a thread to decrement the refcount if it doesn't "own" it,
 	 * as that can result in the thread that loses the race to 0
 	 * operating on an already-freed object.
@@ -481,7 +481,7 @@ int json_object_object_add_ex(struct json_object* jso,
 	// We lookup the entry and replace the value, rather than just deleting
 	// and re-adding it, so the existing key remains valid.
 	hash = lh_get_hash(jso->o.c_object, (const void *)key);
-	existing_entry = (opts & JSON_C_OBJECT_ADD_KEY_IS_NEW) ? NULL : 
+	existing_entry = (opts & JSON_C_OBJECT_ADD_KEY_IS_NEW) ? NULL :
 			      lh_table_lookup_entry_w_hash(jso->o.c_object,
 							   (const void *)key, hash);
 
@@ -734,6 +734,61 @@ int json_object_int_inc(struct json_object *jso, int64_t val) {
 	} else {
 		jso->o.c_int64 += val;
 	}
+	return 1;
+}
+
+static int json_object_uint_to_json_string(struct json_object* jso,
+					  struct printbuf *pb,
+					  int level,
+					  int flags)
+{
+	/* room for 20 digits and a null term */
+	char sbuf[21];
+	snprintf(sbuf, sizeof(sbuf), "%" PRIu64, jso->o.c_uint64);
+	return printbuf_memappend (pb, sbuf, strlen(sbuf));
+}
+
+struct json_object* json_object_new_uint64(uint64_t u)
+{
+	struct json_object *jso = json_object_new(json_type_int);
+	if (!jso)
+		return NULL;
+	jso->_to_json_string = &json_object_uint_to_json_string;
+	jso->o.c_uint64 = u;
+	return jso;
+}
+
+uint64_t json_object_get_uint64(const struct json_object *jso)
+{
+	uint64_t u;
+
+	if (!jso)
+		return 0;
+	switch(jso->o_type)
+	{
+	case json_type_int:
+		return jso->o.c_uint64;
+	case json_type_double:
+		if (jso->o.c_double >= UINT64_MAX)
+			return UINT64_MAX;
+		if (jso->o.c_double <= 0)
+			return 0;
+		return (uint64_t)jso->o.c_double;
+	case json_type_boolean:
+		return jso->o.c_boolean;
+	case json_type_string:
+		if (json_parse_uint64(get_string_component(jso), &u) == 0)
+			return u;
+		/* FALLTHRU */
+	default:
+		return 0;
+	}
+}
+
+int json_object_set_uint64(struct json_object *jso, uint64_t new_value) {
+	if (!jso || jso->o_type != json_type_int)
+		return 0;
+	jso->o.c_uint64 = new_value;
 	return 1;
 }
 
@@ -1094,11 +1149,11 @@ int json_object_set_string(json_object* jso, const char* s) {
 }
 
 int json_object_set_string_len(json_object* jso, const char* s, int len){
-	char *dstbuf; 
-	if (jso==NULL || jso->o_type!=json_type_string) return 0; 	
+	char *dstbuf;
+	if (jso==NULL || jso->o_type!=json_type_string) return 0;
 	if (len<LEN_DIRECT_STRING_DATA) {
 		dstbuf=jso->o.c_string.str.data;
-		if (jso->o.c_string.len>=LEN_DIRECT_STRING_DATA) free(jso->o.c_string.str.ptr); 
+		if (jso->o.c_string.len>=LEN_DIRECT_STRING_DATA) free(jso->o.c_string.str.ptr);
 	} else {
 		dstbuf=(char *)malloc(len+1);
 		if (dstbuf==NULL) return 0;
@@ -1108,7 +1163,7 @@ int json_object_set_string_len(json_object* jso, const char* s, int len){
 	jso->o.c_string.len=len;
 	memcpy(dstbuf, (const void *)s, len);
 	dstbuf[len] = '\0';
-	return 1; 
+	return 1;
 }
 
 /* json_object_array */
@@ -1500,4 +1555,3 @@ int json_object_deep_copy(struct json_object *src, struct json_object **dst, jso
 
 	return rc;
 }
-

--- a/json_object.h
+++ b/json_object.h
@@ -33,7 +33,7 @@
 #define JSON_C_CONST_FUNCTION(func) func
 #endif
 
-#if defined(_MSC_VER) 
+#if defined(_MSC_VER)
 #define JSON_EXPORT __declspec(dllexport)
 #else
 #define JSON_EXPORT extern
@@ -430,7 +430,7 @@ JSON_EXPORT int json_object_object_add(struct json_object* obj, const char *key,
  * @param obj the json_object instance
  * @param key the object field name (a private copy will be duplicated)
  * @param val a json_object or NULL member to associate with the given field
- * @param opts process-modifying options. To specify multiple options, use 
+ * @param opts process-modifying options. To specify multiple options, use
  *             arithmetic or (OPT1|OPT2)
  */
 JSON_EXPORT int json_object_object_add_ex(struct json_object* obj,
@@ -636,7 +636,7 @@ JSON_EXPORT struct json_object* json_object_array_get_idx(const struct json_obje
 /** Delete an elements from a specified index in an array (a json_object of type json_type_array)
  *
  * The reference count will be decremented for each of the deleted objects.  If there
- * are no more owners of an element that is being deleted, then the value is 
+ * are no more owners of an element that is being deleted, then the value is
  * freed.  Otherwise, the reference to the value will remain in memory.
  *
  * @param obj the json_object instance
@@ -669,8 +669,8 @@ JSON_EXPORT json_bool json_object_get_boolean(const struct json_object *obj);
 
 
 /** Set the json_bool value of a json_object
- * 
- * The type of obj is checked to be a json_type_boolean and 0 is returned 
+ *
+ * The type of obj is checked to be a json_type_boolean and 0 is returned
  * if it is not without any further actions. If type of obj is json_type_boolean
  * the object value is changed to new_value
  *
@@ -699,6 +699,13 @@ JSON_EXPORT struct json_object* json_object_new_int(int32_t i);
 JSON_EXPORT struct json_object* json_object_new_int64(int64_t i);
 
 
+/** Create a new empty json_object of type json_type_int
+ * @param i the integer
+ * @returns a json_object of type json_type_int
+ */
+JSON_EXPORT struct json_object* json_object_new_uint64(uint64_t i);
+
+
 /** Get the int value of a json_object
  *
  * The type is coerced to a int if the passed object is not a int.
@@ -716,8 +723,8 @@ JSON_EXPORT struct json_object* json_object_new_int64(int64_t i);
 JSON_EXPORT int32_t json_object_get_int(const struct json_object *obj);
 
 /** Set the int value of a json_object
- * 
- * The type of obj is checked to be a json_type_int and 0 is returned 
+ *
+ * The type of obj is checked to be a json_type_int and 0 is returned
  * if it is not without any further actions. If type of obj is json_type_int
  * the object value is changed to new_value
  *
@@ -761,8 +768,8 @@ JSON_EXPORT int64_t json_object_get_int64(const struct json_object *obj);
 
 
 /** Set the int64_t value of a json_object
- * 
- * The type of obj is checked to be a json_type_int and 0 is returned 
+ *
+ * The type of obj is checked to be a json_type_int and 0 is returned
  * if it is not without any further actions. If type of obj is json_type_int
  * the object value is changed to new_value
  *
@@ -878,8 +885,8 @@ JSON_EXPORT double json_object_get_double(const struct json_object *obj);
 
 
 /** Set the double value of a json_object
- * 
- * The type of obj is checked to be a json_type_double and 0 is returned 
+ *
+ * The type of obj is checked to be a json_type_double and 0 is returned
  * if it is not without any further actions. If type of obj is json_type_double
  * the object value is changed to new_value
  *
@@ -951,8 +958,8 @@ JSON_EXPORT int json_object_get_string_len(const struct json_object *obj);
 JSON_EXPORT int json_object_set_string(json_object* obj, const char* new_value);
 
 /** Set the string value of a json_object str
- * 
- * The type of obj is checked to be a json_type_string and 0 is returned 
+ *
+ * The type of obj is checked to be a json_type_string and 0 is returned
  * if it is not without any further actions. If type of obj is json_type_string
  * the object value is changed to new_value
  *
@@ -991,7 +998,7 @@ JSON_EXPORT int json_object_equal(struct json_object *obj1,
  * When shallow_copy is called *dst will be NULL, and must be non-NULL when it returns.
  * src will never be NULL.
  *
- * If shallow_copy sets the serializer on an object, return 2 to indicate to 
+ * If shallow_copy sets the serializer on an object, return 2 to indicate to
  *  json_object_deep_copy that it should not attempt to use the standard userdata
  *  copy function.
  *
@@ -1001,7 +1008,7 @@ typedef int (json_c_shallow_copy_fn)(json_object *src, json_object *parent, cons
 
 /**
  * The default shallow copy implementation for use with json_object_deep_copy().
- * This simply calls the appropriate json_object_new_<type>() function and 
+ * This simply calls the appropriate json_object_new_<type>() function and
  * copies over the serializer function (_to_json_string internal field of
  * the json_object structure) but not any _userdata or _user_delete values.
  *
@@ -1032,7 +1039,7 @@ json_c_shallow_copy_fn json_c_shallow_copy_default;
  *          or if the destination pointer is non-NULL
  */
 
-JSON_EXPORT int json_object_deep_copy(struct json_object *src, struct json_object **dst, json_c_shallow_copy_fn *shallow_copy); 
+JSON_EXPORT int json_object_deep_copy(struct json_object *src, struct json_object **dst, json_c_shallow_copy_fn *shallow_copy);
 #ifdef __cplusplus
 }
 #endif

--- a/json_object_private.h
+++ b/json_object_private.h
@@ -35,6 +35,7 @@ struct json_object
     json_bool c_boolean;
     double c_double;
     int64_t c_int64;
+    uint64_t c_uint64;
     struct lh_table *c_object;
     struct array_list *c_array;
     struct {

--- a/json_util.c
+++ b/json_util.c
@@ -207,6 +207,18 @@ int json_parse_int64(const char *buf, int64_t *retval)
 	return ((val == 0 && errno != 0) || (end == buf)) ? 1 : 0;
 }
 
+int json_parse_uint64(const char *buf, uint64_t *retval)
+{
+	char *end = NULL;
+	uint64_t val;
+
+	errno = 0;
+	val = strtoull(buf, &end, 10);
+	if (end != buf)
+		*retval = val;
+	return ((val == 0 && errno != 0) || (end == buf)) ? 1 : 0;
+}
+
 #ifndef HAVE_REALLOC
 void* rpl_realloc(void* p, size_t n)
 {
@@ -240,4 +252,3 @@ const char *json_type_to_name(enum json_type o_type)
 	}
 	return json_type_name[o_type];
 }
-

--- a/json_util.h
+++ b/json_util.h
@@ -12,7 +12,7 @@
 /**
  * @file
  * @brief Miscllaneous utility functions and macros.
- */ 
+ */
 #ifndef _json_util_h_
 #define _json_util_h_
 
@@ -91,6 +91,7 @@ const char *json_util_get_last_err(void);
 
 
 extern int json_parse_int64(const char *buf, int64_t *retval);
+extern int json_parse_uint64(const char *buf, uint64_t *retval);
 extern int json_parse_double(const char *buf, double *retval);
 
 /**


### PR DESCRIPTION
The JSON spec doesn't bound JSON numbers. In order to be able to store values
greater than INT64_MAX, adding uint64 support is required.