### PR TITLE
Install CMake module files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,12 +166,6 @@ message(STATUS "Written ${PROJECT_BINARY_DIR}/config.h")
 configure_file(${PROJECT_SOURCE_DIR}/cmake/json_config.h.in   ${PROJECT_BINARY_DIR}/json_config.h)
 message(STATUS "Written ${PROJECT_BINARY_DIR}/json_config.h")
 
-configure_package_config_file(
-    "cmake/Config.cmake.in"
-    ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
-)
-
 if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections")
     # There's a catch here.
@@ -248,14 +242,35 @@ add_library(${PROJECT_NAME}
 
 # If json-c is used as subroject it set to target correct interface -I flags and allow
 # to build external target without extra include_directories(...)
-set_property(TARGET ${PROJECT_NAME} PROPERTY
-    INTERFACE_INCLUDE_DIRECTORIES ${PROJECT_SOURCE_DIR} ${PROJECT_BINARY_DIR}
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
 )
 
 install(TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
+    EXPORT ${PROJECT_NAME}-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(EXPORT ${PROJECT_NAME}-targets
+    FILE ${PROJECT_NAME}-targets.cmake
+    NAMESPACE ${PROJECT_NAME}::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
+
+configure_package_config_file(
+    "cmake/Config.cmake.in"
+    ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)
+
+install(
+    FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )
 
 if (UNIX OR MINGW OR CYGWIN)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,4 +1,4 @@
 @PACKAGE_INIT@
 
-include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
This patch exports the CMake install target so that the users can install the CMake module files and use them in a CMake-based project like this:
```cmake
find_package(json-c CONFIG REQUIRED)
add_executable(json_c_test json_c_test.c)
target_link_libraries(json_c_test PRIVATE json-c::json-c)
```

The `json-c` target is put under `json-c::` namespace:
https://github.com/myd7349/json-c/blob/c2036ab9fc602cca8c9f200d6fe25d443b3b169e/CMakeLists.txt#L261

If:
```cmake
target_link_libraries(json_c_test PRIVATE json-c)
```
is more preferable, we may just delete that line.