### PR TITLE
do not compile with -Werror by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - ./configure
 
 script:
-  - make
+  - make AM_CFLAGS="-Werror"
 
 after_success:
   - make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - ./configure
 
 script:
-  - make AM_CFLAGS="-Werror"
+  - make V=1 AM_CFLAGS="-Werror"
 
 after_success:
   - make check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,9 +168,6 @@ message(STATUS "Written ${PROJECT_BINARY_DIR}/json_config.h")
 
 if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections")
-    # There's a catch here.
-    set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} -Werror")
-
     add_definitions(-D_GNU_SOURCE)
 elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
     set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} /DEBUG")

--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@ Deprecated and removed features:
 
 Build changes:
 --------------
+* Do not compile with -Werror by default
 
 0.13.1 (up to commit 0f814e5, 2018/03/04)
 =========================================

--- a/configure.ac
+++ b/configure.ac
@@ -165,8 +165,7 @@ AS_IF([test "x$enable_Bsymbolic" = "xcheck"],
 AS_IF([test "x$enable_Bsymbolic" = "xyes"], [JSON_BSYMBOLIC_LDFLAGS=-Wl[,]-Bsymbolic-functions])
 AC_SUBST(JSON_BSYMBOLIC_LDFLAGS)
 
-AX_APPEND_COMPILE_FLAGS([-Wall -Werror -Wcast-qual -Wno-error=deprecated-declarations])
-AX_APPEND_COMPILE_FLAGS([-Wextra -Wwrite-string -Wno-unused-parameter])
+AX_APPEND_COMPILE_FLAGS([-Wall -Wextra -Wcast-qual -Wwrite-strings -Wno-unused-parameter])
 AX_APPEND_COMPILE_FLAGS([-D_GNU_SOURCE])
 
 AC_LANG_PUSH([C])


### PR DESCRIPTION
but do test build with `-Werror`

also fix `-Wwrite-string` to `-Wwrite-strings`

fixes #489 