### PR TITLE
test/Makefile.am:add missing deps for test1 and test2

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -45,6 +45,8 @@ test1Formatted_CPPFLAGS = $(AM_CPPFLAGS) -DTEST_FORMATTED
 EXTRA_DIST+= test1Formatted_plain.expected
 EXTRA_DIST+= test1Formatted_pretty.expected
 EXTRA_DIST+= test1Formatted_spaced.expected
+EXTRA_DIST+= test1Formatted_spaced_pretty.expected
+EXTRA_DIST+= test1Formatted_spaced_pretty_pretty_tab.expected
 
 # Note: handled by test2.test
 check_PROGRAMS += test2Formatted
@@ -53,6 +55,8 @@ test2Formatted_CPPFLAGS = $(AM_CPPFLAGS) -DTEST_FORMATTED
 EXTRA_DIST+= test2Formatted_plain.expected
 EXTRA_DIST+= test2Formatted_pretty.expected
 EXTRA_DIST+= test2Formatted_spaced.expected
+EXTRA_DIST+= test2Formatted_spaced_pretty.expected
+EXTRA_DIST+= test2Formatted_spaced_pretty_pretty_tab.expected
 
 test_util_file_SOURCES = test_util_file.c
 


### PR DESCRIPTION
Allows the tests to pass when running `make distcheck`

This fixes the 2 broken tests I mentioned at
https://github.com/json-c/json-c/pull/499#discussion_r306998261