### PR TITLE
undefine NDEBUG for tests

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/tests
+AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/tests -UNDEBUG
 
 LDADD= $(LIBJSON_LA)
 


### PR DESCRIPTION
resolves #406 

I also added `-UNDEBUG` to tests/Makefile.am to make sure NDEBUG is always undefined for tests. (So if someone had debugging enabled, they won't have to re-run `configure --enable-debug=off` just to undefine it.)

Adding this arg to configure also will allow for turning on [profiling](https://sourceware.org/binutils/docs/gprof/), which can't really be used with the library by itself, afaik, but perhaps in the future a test may be added to utilize it.