### PR TITLE
Properly append to CMAKE_C_FLAGS string

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,6 @@ endforeach(TESTNAME)
 
 # Make sure NDEBUG is always undefined for tests
 if (UNIX OR MINGW OR CYGWIN)
-    list(APPEND CMAKE_C_FLAGS -UNDEBUG)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -UNDEBUG")
 endif()
 


### PR DESCRIPTION
Contrary to other CMAKE variables the CMAKE_C_FLAGS variable is the
composed string of flags for the C compiler. It is therefore not a list
to append to. Current implementation results in these incorrect CFLAGS,
e.g., "-O2 -g -fblahblah;-UNDEBUG". Extending the CFLAGS this way
results in the proper CFLAGS, e.g., "-O2 -g -fblahblah -UNDEBUG".