### PR TITLE
validate utf-8 string before parse

### DIFF
--- a/json_tokener.h
+++ b/json_tokener.h
@@ -38,6 +38,7 @@ enum json_tokener_error {
   json_tokener_error_parse_object_value_sep,
   json_tokener_error_parse_string,
   json_tokener_error_parse_comment,
+  json_tokener_error_parse_utf8_string,
   json_tokener_error_size
 };
 
@@ -161,6 +162,12 @@ JSON_EXPORT void json_tokener_free(struct json_tokener *tok);
 JSON_EXPORT void json_tokener_reset(struct json_tokener *tok);
 JSON_EXPORT struct json_object* json_tokener_parse(const char *str);
 JSON_EXPORT struct json_object* json_tokener_parse_verbose(const char *str, enum json_tokener_error *error);
+
+/**
+ * validete the utf-8 string before parse in strict model.
+ * if not utf-8 format, return err.
+ */
+json_bool json_tokener_validate_utf8(const char *str);
 
 /**
  * Set flags that control how parsing will be done.

--- a/tests/test_parse.c
+++ b/tests/test_parse.c
@@ -355,6 +355,28 @@ struct incremental_step {
 	{ "[1,2,3,]",         -1, 7, json_tokener_error_parse_unexpected, 3 },
 	{ "{\"a\":1,}",         -1, 7, json_tokener_error_parse_unexpected, 3 },
 
+  // acsll encoding "123asc$%&"
+	{ "\x22\x31\x32\x33\x61\x73\x63\x24\x25\x26\x22", -1, -1, json_tokener_success, 3 },
+	{ "\x22\x31\x32\x33\x61\x73\x63\x24\x25\x26\x22", -1, -1, json_tokener_success, 1 },
+  // utf-8 encoding "世界" "πφ" "𥑕"
+	{ "\x22\xe4\xb8\x96\xe7\x95\x8c\x22", -1, -1, json_tokener_success, 3 },
+	{ "\x22\xe4\xb8\x96\xe7\x95\x8c\x22", -1, -1, json_tokener_success, 1 },
+	{ "\x22\xcf\x80\xcf\x86\x22", -1, -1, json_tokener_success, 3 },
+	{ "\x22\xf0\xa5\x91\x95\x22", -1, -1, json_tokener_success, 3 },
+	{ "\x22\xf8\xa5\xa5\x91\x95\x22", -1, -1, json_tokener_success, 3 },
+	{ "\x22\xfd\xa5\xa5\xa5\x91\x95\x22", -1, -1, json_tokener_success, 3 },
+  // wrong utf-8 encoding
+	{ "\x22\xe6\x9d\x4e\x22", -1, 0, json_tokener_error_parse_utf8_string, 3 },
+	{ "\x22\xe6\x9d\x4e\x22", -1, 5, json_tokener_success, 1 },
+  // GBK encoding
+	{ "\x22\xc0\xee\xc5\xf4\x22", -1, 0, json_tokener_error_parse_utf8_string, 3 },
+	{ "\x22\xc0\xee\xc5\xf4\x22", -1, 6, json_tokener_success, 1 },
+  // ucs-2/utf-16 encoding
+	{ "\x22\x11\xd2\x22", -1, 0, json_tokener_error_parse_utf8_string, 3 },
+	{ "\x22\x11\xd2\x22", -1, 4, json_tokener_success, 1 },
+	{ "\x22\x55\xd8\55\xdc\x22", -1, 0, json_tokener_error_parse_utf8_string, 3 },
+	{ "\x22\x16\x4e\x4c\x75\x22", -1, 6, json_tokener_success, 1 },
+
 	{ NULL, -1, -1, json_tokener_success, 0 },
 };
 

--- a/tests/test_parse.expected
+++ b/tests/test_parse.expected
@@ -183,5 +183,21 @@ json_tokener_parse_ex(tok, [1,2,3,]    ,   8) ... OK: got object of type [array]
 json_tokener_parse_ex(tok, [1,2,,3,]   ,   9) ... OK: got correct error: unexpected character
 json_tokener_parse_ex(tok, [1,2,3,]    ,   8) ... OK: got correct error: unexpected character
 json_tokener_parse_ex(tok, {"a":1,}    ,   8) ... OK: got correct error: unexpected character
-End Incremental Tests OK=105 ERROR=0
+json_tokener_parse_ex(tok, "123asc$%&" ,  11) ... OK: got object of type [string]: "123asc$%&"
+json_tokener_parse_ex(tok, "123asc$%&" ,  11) ... OK: got object of type [string]: "123asc$%&"
+json_tokener_parse_ex(tok, "ä¸–ç•Œ"    ,   8) ... OK: got object of type [string]: "ä¸–ç•Œ"
+json_tokener_parse_ex(tok, "ä¸–ç•Œ"    ,   8) ... OK: got object of type [string]: "ä¸–ç•Œ"
+json_tokener_parse_ex(tok, "Ï€Ï†"      ,   6) ... OK: got object of type [string]: "Ï€Ï†"
+json_tokener_parse_ex(tok, "ğ¥‘•"      ,   6) ... OK: got object of type [string]: "ğ¥‘•"
+json_tokener_parse_ex(tok, "ø¥¥‘•"     ,   7) ... OK: got object of type [string]: "ø¥¥‘•"
+json_tokener_parse_ex(tok, "ı¥¥¥‘•"    ,   8) ... OK: got object of type [string]: "ı¥¥¥‘•"
+json_tokener_parse_ex(tok, "æN"       ,   5) ... OK: got correct error: invalid utf-8 string
+json_tokener_parse_ex(tok, "æN"       ,   5) ... OK: got object of type [string]: "æN"
+json_tokener_parse_ex(tok, "ÀîÅô"      ,   6) ... OK: got correct error: invalid utf-8 string
+json_tokener_parse_ex(tok, "ÀîÅô"      ,   6) ... OK: got object of type [string]: "ÀîÅô"
+json_tokener_parse_ex(tok, "Ò"        ,   4) ... OK: got correct error: invalid utf-8 string
+json_tokener_parse_ex(tok, "Ò"        ,   4) ... OK: got object of type [string]: "\u0011Ò"
+json_tokener_parse_ex(tok, "UØ-Ü"      ,   6) ... OK: got correct error: invalid utf-8 string
+json_tokener_parse_ex(tok, "NLu"      ,   6) ... OK: got object of type [string]: "\u0016NLu"
+End Incremental Tests OK=121 ERROR=0
 ==================================


### PR DESCRIPTION
validate utf-8 string before parse. Fix #122 