### PR TITLE
Replace '\0' only when parsing key, not change data in value.

### DIFF
--- a/tests/test_parse.c
+++ b/tests/test_parse.c
@@ -121,6 +121,7 @@ static void test_basic_parse()
 	single_basic_parse("{ \"foo\": [null, \"foo\"] }", 0);
 	single_basic_parse("{ \"abc\": 12, \"foo\": \"bar\", \"bool0\": false, \"bool1\": true, \"arr\": [ 1, 2, 3, null, 5 ] }", 0);
 	single_basic_parse("{ \"abc\": \"blue\nred\\ngreen\" }", 0);
+	single_basic_parse("{ \"foo\\u0000bar\": \"foo\\u0000bar\" }", 0);
 
 	// Clear serializer for these tests so we see the actual parsed value.
 	single_basic_parse("null", 1);

--- a/tests/test_parse.expected
+++ b/tests/test_parse.expected
@@ -61,6 +61,7 @@ new_obj.to_string({ "foo": [null, "foo"] })={ "foo": [ null, "foo" ] }
 new_obj.to_string({ "abc": 12, "foo": "bar", "bool0": false, "bool1": true, "arr": [ 1, 2, 3, null, 5 ] })={ "abc": 12, "foo": "bar", "bool0": false, "bool1": true, "arr": [ 1, 2, 3, null, 5 ] }
 new_obj.to_string({ "abc": "blue
 red\ngreen" })={ "abc": "blue\nred\ngreen" }
+new_obj.to_string({ "foo\u0000bar": "foo\u0000bar" })={ "foo\\u0000bar": "foo\u0000bar" }
 new_obj.to_string(null)=null
 new_obj.to_string(false)=false
 new_obj.to_string([0e])=[ 0.0 ]


### PR DESCRIPTION
Before the hash value is calculated, the replacement "\ 0" operation is placed first, and then the parsing of the value will preserve the original logic. #528 