### PR TITLE
add coveralls auto tool to json-c

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,22 +78,33 @@ matrix:
       osx_image: xcode10.1
       env: XCODE="true" CHECK="true"
 
-#   run coveralls
+# run coveralls
     - os: linux
       dist: xenial
       compiler: gcc
       env: CHECK="true"
+      install:
+        - sh autogen.sh
       before_install:
         - sudo pip install cpp-coveralls
+        - echo $CC
+        - echo $LANG
+        - echo $LC_ALL
+        - set -e
+        - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+            eval "${MATRIX_EVAL}";
+            if [ -n "$MATRIX_EVAL" ] && [ "$TRAVIS_COMPILER" != "clang" ]; then
+              sudo apt-get install -y $CC;
+            fi;
+          fi
+      before_script:
+        - export CFLAGS="-fprofile-arcs -ftest-coverage"
+        - ./configure
       script:
-        - mkdir build
-        - cd build
-        - cmake ..
         - make
-        - make test
-        - cd -
+        - make check
       after_success:
-        - coveralls --include arraylist.c --include arraylist.h --include json_object.c --include json_object.h --include json_object_iterator.c --include json_object_iterator.h --include json_object_private.h --include json_pointer.c --include json_pointer.h --include json_tokener.c --include json_tokener.h --include json_util.c --include json_util.h --include json_visit.c --include json_visit.h --include linkhash.c --include linkhash.h --include printbuf.c --include printbuf.h --include random_seed.c --include strerror_override.c
+        - coveralls --exclude tests --exclude fuzz
 
 #  allow_failures:
 #    - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,23 @@ matrix:
       osx_image: xcode10.1
       env: XCODE="true" CHECK="true"
 
+#   run coveralls
+    - os: linux
+      dist: xenial
+      compiler: gcc
+      env: CHECK="true"
+      before_install:
+        - sudo pip install cpp-coveralls
+      script:
+        - mkdir build
+        - cd build
+        - cmake ..
+        - make
+        - make test
+        - cd -
+      after_success:
+        - coveralls --include arraylist.c --include arraylist.h --include json_object.c --include json_object.h --include json_object_iterator.c --include json_object_iterator.h --include json_object_private.h --include json_pointer.c --include json_pointer.h --include json_tokener.c --include json_tokener.h --include json_util.c --include json_util.h --include json_visit.c --include json_visit.h --include linkhash.c --include linkhash.h --include printbuf.c --include printbuf.h --include random_seed.c --include strerror_override.c
+
 #  allow_failures:
 #    - os: osx
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ message(STATUS "Written ${PROJECT_BINARY_DIR}/json_config.h")
 
 if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections")
+    set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
 	if ("${DISABLE_WERROR}" STREQUAL "OFF")
 	    set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} -Werror")
 	endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,6 @@ message(STATUS "Written ${PROJECT_BINARY_DIR}/json_config.h")
 
 if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections")
-    set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
 	if ("${DISABLE_WERROR}" STREQUAL "OFF")
 	    set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} -Werror")
 	endif()


### PR DESCRIPTION
This PR adds the coveralls auto tool to json-c.  [Coveralls](https://coveralls.io/) is a web service to help you track your code coverage over time, and ensure that all your new code is fully covered.

I have added it in [dota17/json-c](https://github.com/dota17/json-c?organization=dota17&organization=dota17) and showed a PR submission example in [here](https://github.com/dota17/json-c/pull/40). We can see the json-c's  code coverage in README.md and get the code coverage report from coveralls automatically when you submit a PR. It is a useful and helpful tool.

Following are the configuration steps：
1. Sign in the https://coveralls.io/ with github account and open the switch of json-c/json-c in [```ADD REPO``` ](https://coveralls.io/repos/new).
2. configure file: 
![2020-02-18_111510](https://user-images.githubusercontent.com/50514813/74700995-478c8f00-5240-11ea-8ac9-4279379f26e1.png)
![2020-02-18_111913](https://user-images.githubusercontent.com/50514813/74701272-2e381280-5241-11ea-8ab3-7f887481f282.png)
![2020-02-18_112032](https://user-images.githubusercontent.com/50514813/74701277-33955d00-5241-11ea-806e-26c1e210a9f9.png)
note: ```Compact``` means that you will get a neat and clear report. 
3. Merge this pr.
4. Get and add the badge into README.md 
![2020-02-18_112847](https://user-images.githubusercontent.com/50514813/74701532-f9788b00-5241-11ea-9670-10cd34b4ed60.png)
These steps are simple and coveralls is an interesting and useful tool.  You will like it. （‐＾▽＾‐）