### PR TITLE
add doc target in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,24 @@ set(JSON_C_SOURCES
 include_directories(${PROJECT_SOURCE_DIR})
 include_directories(${PROJECT_BINARY_DIR})
 
+# generate doxygen documentation for json-c API
+
+find_package(Doxygen)
+option(BUILD_DOCUMENTATION "Create and install the HTML based API documentation(requires Doxygen)" ${DOXYGEN_FOUND})
+
+if (DOXYGEN_FOUND)
+
+	add_custom_target(doc
+  	COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_BINARY_DIR}/Doxyfile
+		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+	
+	# request to configure the file
+	configure_file(Doxyfile Doxyfile)
+
+else (DOXYGEN_FOUND)
+	message("Doxygen need to be installed to generate the doxygen documentation")
+endif(DOXYGEN_FOUND)
+
 # XXX for a normal full distribution we'll need to figure out
 # XXX how to build both shared and static libraries.
 # Probably leverage that to build a local VALGRIND=1 library for testing too.

--- a/README.md
+++ b/README.md
@@ -230,6 +230,14 @@ JSONC_TEST_TRACE=1 make test
 ```
 and check the log files again.
 
+To get doxygen documentation
+
+The libray documentation can be generated directly from the source codes using Doxygen tool:
+
+```sh
+make doc
+google-chrome ../doc/html/index.html
+```
 
 
 Linking to `libjson-c` <a name="linking">


### PR DESCRIPTION
1. add doc target in cmake and use doxygen tool to get API documentation. 
```
cmake ..
make doc
```
2. add ```make doc``` description in README.md.