### PR TITLE
modify json-c default build type, and fix up the assert() errors in t…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE debug)
 endif()
 
-set(CMAKE_C_FLAGS_RELEASE   "${CMAKE_C_FLAGS_RELAESE} -O2")
+set(CMAKE_C_FLAGS_RELEASE   "${CMAKE_C_FLAGS_RELEASE} -O2")
 
 # Include file check macros honor CMAKE_REQUIRED_LIBRARIES
 # i.e. the check_include_file() calls will include -lm when checking.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE debug)
 endif()
 
+set(CMAKE_C_FLAGS_RELEASE   "${CMAKE_C_FLAGS_RELAESE} -O2")
+
 # Include file check macros honor CMAKE_REQUIRED_LIBRARIES
 # i.e. the check_include_file() calls will include -lm when checking.
 if(POLICY CMP0075)
@@ -242,9 +244,6 @@ elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
     set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} /wd4127")
     set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} /wd4701")
 endif()
-
-set(CMAKE_C_FLAGS_DEBUG     "${CMAKE_C_FLAGS_DEBUG} -O0")
-set(CMAKE_C_FLAGS_Release   "${CMAKE_C_FLAGS_Release} -O2")
 
 if (NOT ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC"))
 	check_c_source_compiles(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,11 @@ if(POLICY CMP0054)
     cmake_policy(SET CMP0054 NEW)
 endif()
 
+# set default build type if not specified by user
+if(NOT CMAKE_BUILD_TYPE)
+	set(CMAKE_BUILD_TYPE debug)
+endif()
+
 # Include file check macros honor CMAKE_REQUIRED_LIBRARIES
 # i.e. the check_include_file() calls will include -lm when checking.
 if(POLICY CMP0075)
@@ -237,6 +242,9 @@ elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
     set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} /wd4127")
     set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} /wd4701")
 endif()
+
+set(CMAKE_C_FLAGS_DEBUG     "${CMAKE_C_FLAGS_DEBUG} -O0")
+set(CMAKE_C_FLAGS_Release   "${CMAKE_C_FLAGS_Release} -O2")
 
 if (NOT ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC"))
 	check_c_source_compiles(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,8 +52,3 @@ target_link_libraries(
 
 endforeach(TESTNAME)
 
-# Make sure NDEBUG is always undefined for tests
-if (UNIX OR MINGW OR CYGWIN)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -UNDEBUG")
-endif()
-

--- a/tests/test_deep_copy.c
+++ b/tests/test_deep_copy.c
@@ -2,7 +2,12 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <string.h>
+#ifdef NDEBUG
+#undef NDEBUG
 #include <assert.h>
+#else
+#include <assert.h>
+#endif
 #include <errno.h>
 #include <time.h>
 

--- a/tests/test_deep_copy.c
+++ b/tests/test_deep_copy.c
@@ -4,10 +4,8 @@
 #include <string.h>
 #ifdef NDEBUG
 #undef NDEBUG
-#include <assert.h>
-#else
-#include <assert.h>
 #endif
+#include <assert.h>
 #include <errno.h>
 #include <time.h>
 

--- a/tests/test_json_pointer.c
+++ b/tests/test_json_pointer.c
@@ -1,6 +1,11 @@
 #include "strerror_override.h"
 #include "strerror_override_private.h"
+#ifdef NDEBUG
+#undef NDEBUG
 #include <assert.h>
+#else
+#include <assert.h>
+#endif
 #include <stdio.h>
 #include <string.h>
 

--- a/tests/test_json_pointer.c
+++ b/tests/test_json_pointer.c
@@ -2,10 +2,8 @@
 #include "strerror_override_private.h"
 #ifdef NDEBUG
 #undef NDEBUG
-#include <assert.h>
-#else
-#include <assert.h>
 #endif
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 


### PR DESCRIPTION
1. Solve the problemof testcase failure during cmake release-building. 
2. Modify json-c default cmake build type.
3. Add the default compilation optimization options.
See details in #548  