### PR TITLE
Changed order of calloc args to match stdlib

### DIFF
--- a/arraylist.c
+++ b/arraylist.c
@@ -46,7 +46,7 @@ array_list_new(array_list_free_fn *free_fn)
   arr->size = ARRAY_LIST_DEFAULT_SIZE;
   arr->length = 0;
   arr->free_fn = free_fn;
-  if(!(arr->array = (void**)calloc(sizeof(void*), arr->size))) {
+  if(!(arr->array = (void**)calloc(arr->size, sizeof(void*)))) {
     free(arr);
     return NULL;
   }

--- a/json_object.c
+++ b/json_object.c
@@ -228,7 +228,7 @@ static struct json_object* json_object_new(enum json_type o_type)
 {
 	struct json_object *jso;
 
-	jso = (struct json_object*)calloc(sizeof(struct json_object), 1);
+	jso = (struct json_object*)calloc(1, sizeof(struct json_object));
 	if (!jso)
 		return NULL;
 	jso->o_type = o_type;


### PR DESCRIPTION
Although it is currently working, it's worth to stick with the stdlib definition to avoid further problems
