### PR TITLE
add the json_types.h to Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,7 @@ libjson_cinclude_HEADERS = \
 	json_object_iterator.h \
 	json_pointer.h \
 	json_tokener.h \
+	json_types.h \
 	json_util.h \
 	json_visit.h \
 	linkhash.h \

--- a/vasprintf_compat.h
+++ b/vasprintf_compat.h
@@ -8,8 +8,6 @@
 
 #include "snprintf_compat.h"
 
-#include <malloc.h>
-
 #if !defined(HAVE_VASPRINTF)
 /* CAW: compliant version of vasprintf */
 static int vasprintf(char **buf, const char *fmt, va_list ap)


### PR DESCRIPTION
When I update dota17/json-c, I found the CI didn't pass. But I do not know why the CI passed in  json-c/json-c master branch. Maybe the CI  do not finish? Coveralls may also be an influencing factor. I close the option ```USE STATUS API?``` in Coveralls. You can hava a try. @hawicz 