### PR TITLE
Install json_types.h with autotools build as well.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,7 @@ libjson_cinclude_HEADERS = \
 	json_object_iterator.h \
 	json_pointer.h \
 	json_tokener.h \
+	json_types.h \
 	json_util.h \
 	json_visit.h \
 	linkhash.h \


### PR DESCRIPTION
Since a recent commit (19bbf2c), this header must also be installed.
Otherwise any software building against json-c fails the build.