### PR TITLE
Adding better support to MinGW

### DIFF
--- a/json_util.c
+++ b/json_util.c
@@ -39,7 +39,7 @@
 #endif /* HAVE_UNISTD_H */
 
 #ifdef WIN32
-#if MSC_VER < 1800
+#if (MSC_VER < 1800) && !defined(__MINGW32__)
 /* strtoll/strtoull is available only since Visual Studio 2013 */
 #define strtoll _strtoi64
 #define strtoull _strtoui64


### PR DESCRIPTION
Adding better support to MinGW by detecting if MinGW is used to avoid MinGW-make to crash:
There was an error caused by the two lines with MinGW:
`#define strtoll _strtoi64`
`#define strtoull _strtoui64`

![image](https://user-images.githubusercontent.com/23421201/78838124-c6f33f00-79f5-11ea-845d-aec3ece9e283.png)
