### PR TITLE
CMake: Bump SONAME to 5.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,8 +365,8 @@ add_library(${PROJECT_NAME}
     ${JSON_C_HEADERS}
 )
 set_target_properties(${PROJECT_NAME} PROPERTIES
-    VERSION 4.0.0
-    SOVERSION 4)
+    VERSION 5.0.0
+    SOVERSION 5)
 
 # If json-c is used as subroject it set to target correct interface -I flags and allow
 # to build external target without extra include_directories(...)


### PR DESCRIPTION
The soname of libjson-c needs to be bumped as there were API changes introduced since the last release:

  * lh_abort() has been removed
  * lh_table_lookup() has been removed
  * TRUE and FALSE defines have been removed