### PR TITLE
CMake: SOVERSION and the major library VERSION need to be in lockstep.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,15 @@ if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING AND
 add_subdirectory(tests)
 endif()
 
+# Library version and SONAME.
+# SOVERSION and the major library VERSION need to be in lockstep.
+# Major library version: Bump this, when interfaces are removed
+# from the API.
+set(LIB_VERSION_MAJOR    4)
+# Library revision: Bump this, when new interfaces are added to
+# the API.  Reset to 0, in case of bumping the major version!
+set(LIB_VERSION_REVISION 0)
+
 # Set some packaging variables.
 set(CPACK_PACKAGE_NAME              "${PROJECT_NAME}")
 set(CPACK_PACKAGE_VERSION_MAJOR     "${PROJECT_VERSION_MAJOR}")
@@ -381,8 +390,8 @@ add_library(${PROJECT_NAME}
     ${JSON_C_HEADERS}
 )
 set_target_properties(${PROJECT_NAME} PROPERTIES
-    VERSION 4.0.0
-    SOVERSION 4)
+    VERSION ${LIB_VERSION_MAJOR}.${LIB_VERSION_REVISION}.0
+    SOVERSION ${LIB_VERSION_MAJOR})
 
 # If json-c is used as subroject it set to target correct interface -I flags and allow
 # to build external target without extra include_directories(...)

--- a/issues_closed_for_0.14.md
+++ b/issues_closed_for_0.14.md
@@ -200,3 +200,4 @@ Issues and Pull Requests closed for the 0.14 release (since commit d582d3a(2017-
 [Issue #579](https://github.com/json-c/json-c/issues/579) - Enforce strict prototypes. \
 [Issue #580](https://github.com/json-c/json-c/issues/580) - Fix CMake tests for enforced strict prototypes. \
 [Issue #581](https://github.com/json-c/json-c/issues/581) - CMakeLists: do not enforce strict prototypes on Windows. \
+[Issue #584](https://github.com/json-c/json-c/issues/584) - CMake: SOVERSION and the major library VERSION need to be in lockstep. \


### PR DESCRIPTION
The SONAME and the major library VERSION always need to be in lockstep.
The major library version MUST be bumped, when an interface is removed from the API.  If new interfaces are added to the API, the library's revision shall be bumped, but MUST be reset to 0 on an event that requires a bump of the major library version.