### PR TITLE
CMake: Do not install config.h, as it is not a public header file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,7 +314,7 @@ set(JSON_C_PUBLIC_HEADERS
     ${PROJECT_SOURCE_DIR}/json_util.h
     ${PROJECT_SOURCE_DIR}/json_visit.h
     ${PROJECT_SOURCE_DIR}/linkhash.h
-    ${PROJECT_SOURCE_DIR}/printbuf.h
+    ${PROJECT_SOURCE_DIR}/json_c_printbuf.h
 )
 
 set(JSON_C_HEADERS
@@ -341,7 +341,7 @@ set(JSON_C_SOURCES
     ${PROJECT_SOURCE_DIR}/json_util.c
     ${PROJECT_SOURCE_DIR}/json_visit.c
     ${PROJECT_SOURCE_DIR}/linkhash.c
-    ${PROJECT_SOURCE_DIR}/printbuf.c
+    ${PROJECT_SOURCE_DIR}/json_c_printbuf.c
     ${PROJECT_SOURCE_DIR}/random_seed.c
     ${PROJECT_SOURCE_DIR}/strerror_override.c
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,7 +299,6 @@ if ($ENV{VALGRIND})
 endif()
 
 set(JSON_C_PUBLIC_HEADERS
-    ${PROJECT_BINARY_DIR}/config.h
     ${PROJECT_BINARY_DIR}/json_config.h
 
     ${PROJECT_SOURCE_DIR}/json.h
@@ -320,6 +319,7 @@ set(JSON_C_PUBLIC_HEADERS
 
 set(JSON_C_HEADERS
     ${JSON_C_PUBLIC_HEADERS}
+    ${PROJECT_BINARY_DIR}/config.h
     ${PROJECT_SOURCE_DIR}/json_object_private.h
     ${PROJECT_SOURCE_DIR}/random_seed.h
     ${PROJECT_SOURCE_DIR}/strerror_override.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,7 +294,7 @@ if (NOT ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC"))
 endif()
 
 if ($ENV{VALGRIND})
-	# Build so that valgrind doesn't complain about linkhash.c
+	# Build so that valgrind doesn't complain about json_c_linkhash.c
     add_definitions(-DVALGRIND=1)
 endif()
 
@@ -313,7 +313,7 @@ set(JSON_C_PUBLIC_HEADERS
     ${PROJECT_SOURCE_DIR}/json_types.h
     ${PROJECT_SOURCE_DIR}/json_util.h
     ${PROJECT_SOURCE_DIR}/json_visit.h
-    ${PROJECT_SOURCE_DIR}/linkhash.h
+    ${PROJECT_SOURCE_DIR}/json_c_linkhash.h
     ${PROJECT_SOURCE_DIR}/json_c_printbuf.h
 )
 
@@ -340,7 +340,7 @@ set(JSON_C_SOURCES
     ${PROJECT_SOURCE_DIR}/json_tokener.c
     ${PROJECT_SOURCE_DIR}/json_util.c
     ${PROJECT_SOURCE_DIR}/json_visit.c
-    ${PROJECT_SOURCE_DIR}/linkhash.c
+    ${PROJECT_SOURCE_DIR}/json_c_linkhash.c
     ${PROJECT_SOURCE_DIR}/json_c_printbuf.c
     ${PROJECT_SOURCE_DIR}/random_seed.c
     ${PROJECT_SOURCE_DIR}/strerror_override.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,7 +303,7 @@ set(JSON_C_PUBLIC_HEADERS
 
     ${PROJECT_SOURCE_DIR}/json.h
     ${PROJECT_SOURCE_DIR}/json_c_arraylist.h
-    ${PROJECT_SOURCE_DIR}/debug.h
+    ${PROJECT_SOURCE_DIR}/json_c_debug.h
     ${PROJECT_SOURCE_DIR}/json_c_version.h
     ${PROJECT_SOURCE_DIR}/json_inttypes.h
     ${PROJECT_SOURCE_DIR}/json_object.h
@@ -332,7 +332,7 @@ set(JSON_C_HEADERS
 
 set(JSON_C_SOURCES
     ${PROJECT_SOURCE_DIR}/json_c_arraylist.c
-    ${PROJECT_SOURCE_DIR}/debug.c
+    ${PROJECT_SOURCE_DIR}/json_c_debug.c
     ${PROJECT_SOURCE_DIR}/json_c_version.c
     ${PROJECT_SOURCE_DIR}/json_object.c
     ${PROJECT_SOURCE_DIR}/json_object_iterator.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,13 +321,13 @@ set(JSON_C_HEADERS
     ${JSON_C_PUBLIC_HEADERS}
     ${PROJECT_BINARY_DIR}/config.h
     ${PROJECT_SOURCE_DIR}/json_object_private.h
-    ${PROJECT_SOURCE_DIR}/random_seed.h
-    ${PROJECT_SOURCE_DIR}/strerror_override.h
-    ${PROJECT_SOURCE_DIR}/strerror_override_private.h
-    ${PROJECT_SOURCE_DIR}/math_compat.h
-    ${PROJECT_SOURCE_DIR}/snprintf_compat.h
-    ${PROJECT_SOURCE_DIR}/strdup_compat.h
-    ${PROJECT_SOURCE_DIR}/vasprintf_compat.h
+    ${PROJECT_SOURCE_DIR}/json_c_random_seed.h
+    ${PROJECT_SOURCE_DIR}/json_c_strerror_override.h
+    ${PROJECT_SOURCE_DIR}/json_c_strerror_override_private.h
+    ${PROJECT_SOURCE_DIR}/json_c_math_compat.h
+    ${PROJECT_SOURCE_DIR}/json_c_snprintf_compat.h
+    ${PROJECT_SOURCE_DIR}/json_c_strdup_compat.h
+    ${PROJECT_SOURCE_DIR}/json_c_vasprintf_compat.h
 )
 
 set(JSON_C_SOURCES
@@ -342,8 +342,8 @@ set(JSON_C_SOURCES
     ${PROJECT_SOURCE_DIR}/json_visit.c
     ${PROJECT_SOURCE_DIR}/json_c_linkhash.c
     ${PROJECT_SOURCE_DIR}/json_c_printbuf.c
-    ${PROJECT_SOURCE_DIR}/random_seed.c
-    ${PROJECT_SOURCE_DIR}/strerror_override.c
+    ${PROJECT_SOURCE_DIR}/json_c_random_seed.c
+    ${PROJECT_SOURCE_DIR}/json_c_strerror_override.c
 )
 
 include_directories(${PROJECT_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,7 +302,7 @@ set(JSON_C_PUBLIC_HEADERS
     ${PROJECT_BINARY_DIR}/json_config.h
 
     ${PROJECT_SOURCE_DIR}/json.h
-    ${PROJECT_SOURCE_DIR}/arraylist.h
+    ${PROJECT_SOURCE_DIR}/json_c_arraylist.h
     ${PROJECT_SOURCE_DIR}/debug.h
     ${PROJECT_SOURCE_DIR}/json_c_version.h
     ${PROJECT_SOURCE_DIR}/json_inttypes.h
@@ -331,7 +331,7 @@ set(JSON_C_HEADERS
 )
 
 set(JSON_C_SOURCES
-    ${PROJECT_SOURCE_DIR}/arraylist.c
+    ${PROJECT_SOURCE_DIR}/json_c_arraylist.c
     ${PROJECT_SOURCE_DIR}/debug.c
     ${PROJECT_SOURCE_DIR}/json_c_version.c
     ${PROJECT_SOURCE_DIR}/json_object.c

--- a/json.h
+++ b/json.h
@@ -22,7 +22,7 @@ extern "C" {
 #endif
 
 #include "json_c_arraylist.h"
-#include "debug.h"
+#include "json_c_debug.h"
 #include "json_c_version.h"
 #include "json_object.h"
 #include "json_object_iterator.h"

--- a/json.h
+++ b/json.h
@@ -29,7 +29,7 @@ extern "C" {
 #include "json_pointer.h"
 #include "json_tokener.h"
 #include "json_util.h"
-#include "linkhash.h"
+#include "json_c_linkhash.h"
 
 #ifdef __cplusplus
 }

--- a/json.h
+++ b/json.h
@@ -21,7 +21,7 @@
 extern "C" {
 #endif
 
-#include "arraylist.h"
+#include "json_c_arraylist.h"
 #include "debug.h"
 #include "json_c_version.h"
 #include "json_object.h"

--- a/json_c_arraylist.c
+++ b/json_c_arraylist.c
@@ -1,5 +1,5 @@
 /*
- * $Id: arraylist.c,v 1.4 2006/01/26 02:16:28 mclark Exp $
+ * $Id: json_c_arraylist.c,v 1.4 2006/01/26 02:16:28 mclark Exp $
  *
  * Copyright (c) 2004, 2005 Metaparadigm Pte. Ltd.
  * Michael Clark <michael@metaparadigm.com>
@@ -34,7 +34,7 @@
 #endif
 #endif
 
-#include "arraylist.h"
+#include "json_c_arraylist.h"
 
 struct array_list *array_list_new(array_list_free_fn *free_fn)
 {

--- a/json_c_arraylist.h
+++ b/json_c_arraylist.h
@@ -1,5 +1,5 @@
 /*
- * $Id: arraylist.h,v 1.4 2006/01/26 02:16:28 mclark Exp $
+ * $Id: json_c_arraylist.h,v 1.4 2006/01/26 02:16:28 mclark Exp $
  *
  * Copyright (c) 2004, 2005 Metaparadigm Pte. Ltd.
  * Michael Clark <michael@metaparadigm.com>
@@ -15,8 +15,8 @@
  *        Although this is exposed by the json_object_get_array() method,
  *        it is not recommended for direct use.
  */
-#ifndef _arraylist_h_
-#define _arraylist_h_
+#ifndef _json_c_arraylist_h_
+#define _json_c_arraylist_h_
 
 #ifdef __cplusplus
 extern "C" {

--- a/json_c_debug.c
+++ b/json_c_debug.c
@@ -1,5 +1,5 @@
 /*
- * $Id: debug.c,v 1.5 2006/01/26 02:16:28 mclark Exp $
+ * $Id: json_c_debug.c,v 1.5 2006/01/26 02:16:28 mclark Exp $
  *
  * Copyright (c) 2004, 2005 Metaparadigm Pte. Ltd.
  * Michael Clark <michael@metaparadigm.com>
@@ -28,7 +28,7 @@
 #include <sys/param.h>
 #endif /* HAVE_SYS_PARAM_H */
 
-#include "debug.h"
+#include "json_c_debug.h"
 
 static int _syslog = 0;
 static int _debug = 0;

--- a/json_c_debug.h
+++ b/json_c_debug.h
@@ -1,5 +1,5 @@
 /*
- * $Id: debug.h,v 1.5 2006/01/30 23:07:57 mclark Exp $
+ * $Id: json_c_debug.h,v 1.5 2006/01/30 23:07:57 mclark Exp $
  *
  * Copyright (c) 2004, 2005 Metaparadigm Pte. Ltd.
  * Michael Clark <michael@metaparadigm.com>

--- a/json_c_linkhash.c
+++ b/json_c_linkhash.c
@@ -1,5 +1,5 @@
 /*
- * $Id: linkhash.c,v 1.4 2006/01/26 02:16:28 mclark Exp $
+ * $Id: json_c_linkhash.c,v 1.4 2006/01/26 02:16:28 mclark Exp $
  *
  * Copyright (c) 2004, 2005 Metaparadigm Pte. Ltd.
  * Michael Clark <michael@metaparadigm.com>
@@ -28,7 +28,7 @@
 #include <windows.h> /* Get InterlockedCompareExchange */
 #endif
 
-#include "linkhash.h"
+#include "json_c_linkhash.h"
 #include "random_seed.h"
 
 /* hash functions */

--- a/json_c_linkhash.c
+++ b/json_c_linkhash.c
@@ -29,7 +29,7 @@
 #endif
 
 #include "json_c_linkhash.h"
-#include "random_seed.h"
+#include "json_c_random_seed.h"
 
 /* hash functions */
 static unsigned long lh_char_hash(const void *k);

--- a/json_c_linkhash.h
+++ b/json_c_linkhash.h
@@ -1,5 +1,5 @@
 /*
- * $Id: linkhash.h,v 1.6 2006/01/30 23:07:57 mclark Exp $
+ * $Id: json_c_linkhash.h,v 1.6 2006/01/30 23:07:57 mclark Exp $
  *
  * Copyright (c) 2004, 2005 Metaparadigm Pte. Ltd.
  * Michael Clark <michael@metaparadigm.com>
@@ -16,8 +16,8 @@
  *        this is exposed by the json_object_get_object() function and within the
  *        json_object_iter type, it is not recommended for direct use.
  */
-#ifndef _linkhash_h_
-#define _linkhash_h_
+#ifndef _json_c_linkhash_h_
+#define _json_c_linkhash_h_
 
 #include "json_object.h"
 
@@ -309,7 +309,7 @@ extern int lh_table_length(struct lh_table *t);
 int lh_table_resize(struct lh_table *t, int new_size);
 
 /**
- * @deprecated Don't use this outside of linkhash.h:
+ * @deprecated Don't use this outside of json_c_linkhash.h:
  */
 #if !defined(_MSC_VER) || (_MSC_VER > 1800)
 /* VS2010 can't handle inline funcs, so skip it there */
@@ -337,7 +337,7 @@ static _LH_INLINE unsigned long lh_get_hash(const struct lh_table *t, const void
 #undef _LH_INLINE
 
 /**
- * @deprecated Don't use this outside of linkhash.h:
+ * @deprecated Don't use this outside of json_c_linkhash.h:
  */
 #ifdef __UNCONST
 #define _LH_UNCONST(a) __UNCONST(a)

--- a/json_c_math_compat.h
+++ b/json_c_math_compat.h
@@ -1,5 +1,5 @@
-#ifndef __math_compat_h
-#define __math_compat_h
+#ifndef __json_c_math_compat_h
+#define __json_c_math_compat_h
 
 /**
  * @file

--- a/json_c_printbuf.c
+++ b/json_c_printbuf.c
@@ -27,8 +27,8 @@
 
 #include "json_c_debug.h"
 #include "json_c_printbuf.h"
-#include "snprintf_compat.h"
-#include "vasprintf_compat.h"
+#include "json_c_snprintf_compat.h"
+#include "json_c_vasprintf_compat.h"
 
 static int printbuf_extend(struct printbuf *p, int min_size);
 

--- a/json_c_printbuf.c
+++ b/json_c_printbuf.c
@@ -1,5 +1,5 @@
 /*
- * $Id: printbuf.c,v 1.5 2006/01/26 02:16:28 mclark Exp $
+ * $Id: json_c_printbuf.c,v 1.5 2006/01/26 02:16:28 mclark Exp $
  *
  * Copyright (c) 2004, 2005 Metaparadigm Pte. Ltd.
  * Michael Clark <michael@metaparadigm.com>
@@ -26,7 +26,7 @@
 #endif /* HAVE_STDARG_H */
 
 #include "json_c_debug.h"
-#include "printbuf.h"
+#include "json_c_printbuf.h"
 #include "snprintf_compat.h"
 #include "vasprintf_compat.h"
 

--- a/json_c_printbuf.h
+++ b/json_c_printbuf.h
@@ -1,5 +1,5 @@
 /*
- * $Id: printbuf.h,v 1.4 2006/01/26 02:16:28 mclark Exp $
+ * $Id: json_c_printbuf.h,v 1.4 2006/01/26 02:16:28 mclark Exp $
  *
  * Copyright (c) 2004, 2005 Metaparadigm Pte. Ltd.
  * Michael Clark <michael@metaparadigm.com>
@@ -20,8 +20,8 @@
  *        json_object_set_serializer() direct use of this is not
  *        recommended.
  */
-#ifndef _printbuf_h_
-#define _printbuf_h_
+#ifndef _json_c_printbuf_h_
+#define _json_c_printbuf_h_
 
 #ifndef JSON_EXPORT
 #if defined(_MSC_VER)

--- a/json_c_random_seed.c
+++ b/json_c_random_seed.c
@@ -1,5 +1,5 @@
 /*
- * random_seed.c
+ * json_c_random_seed.c
  *
  * Copyright (c) 2013 Metaparadigm Pte. Ltd.
  * Michael Clark <michael@metaparadigm.com>
@@ -9,9 +9,9 @@
  *
  */
 
-#include "random_seed.h"
+#include "json_c_random_seed.h"
 #include "config.h"
-#include "strerror_override.h"
+#include "json_c_strerror_override.h"
 #include <stdio.h>
 
 #define DEBUG_SEED(s)

--- a/json_c_random_seed.h
+++ b/json_c_random_seed.h
@@ -1,5 +1,5 @@
 /*
- * random_seed.h
+ * json_c_random_seed.h
  *
  * Copyright (c) 2013 Metaparadigm Pte. Ltd.
  * Michael Clark <michael@metaparadigm.com>

--- a/json_c_snprintf_compat.h
+++ b/json_c_snprintf_compat.h
@@ -1,5 +1,5 @@
-#ifndef __snprintf_compat_h
-#define __snprintf_compat_h
+#ifndef __json_c_snprintf_compat_h
+#define __json_c_snprintf_compat_h
 
 /**
  * @file
@@ -38,4 +38,4 @@ static int json_c_snprintf(char *str, size_t size, const char *format, ...)
 #error Need vsnprintf!
 #endif /* !HAVE_SNPRINTF && defined(WIN32) */
 
-#endif /* __snprintf_compat_h */
+#endif /* __json_c_snprintf_compat_h */

--- a/json_c_strdup_compat.h
+++ b/json_c_strdup_compat.h
@@ -1,5 +1,5 @@
-#ifndef __strdup_compat_h
-#define __strdup_compat_h
+#ifndef __json_c_strdup_compat_h
+#define __json_c_strdup_compat_h
 
 /**
  * @file

--- a/json_c_strerror_override.c
+++ b/json_c_strerror_override.c
@@ -1,5 +1,5 @@
 #define STRERROR_OVERRIDE_IMPL 1
-#include "strerror_override.h"
+#include "json_c_strerror_override.h"
 
 /*
  * Override strerror() to get consistent output across platforms.

--- a/json_c_strerror_override.h
+++ b/json_c_strerror_override.h
@@ -1,5 +1,5 @@
-#ifndef _json_strerror_override_h_
-#define _json_strerror_override_h_
+#ifndef _json_json_c_strerror_override_h_
+#define _json_json_c_strerror_override_h_
 
 /**
  * @file
@@ -27,4 +27,4 @@ JSON_EXPORT char *_json_c_strerror(int errno_in);
 }
 #endif
 
-#endif /* _json_strerror_override_h_ */
+#endif /* _json_json_c_strerror_override_h_ */

--- a/json_c_strerror_override_private.h
+++ b/json_c_strerror_override_private.h
@@ -1,5 +1,5 @@
-#ifndef __json_strerror_override_private_h__
-#define __json_strerror_override_private_h__
+#ifndef __json_json_c_strerror_override_private_h__
+#define __json_json_c_strerror_override_private_h__
 
 /**
  * @file

--- a/json_c_vasprintf_compat.h
+++ b/json_c_vasprintf_compat.h
@@ -1,12 +1,12 @@
-#ifndef __vasprintf_compat_h
-#define __vasprintf_compat_h
+#ifndef __json_c_vasprintf_compat_h
+#define __json_c_vasprintf_compat_h
 
 /**
  * @file
  * @brief Do not use, json-c internal, may be changed or removed at any time.
  */
 
-#include "snprintf_compat.h"
+#include "json_c_snprintf_compat.h"
 
 #include <stdlib.h>
 
@@ -57,4 +57,4 @@ static int vasprintf(char **buf, const char *fmt, va_list ap)
 }
 #endif /* !HAVE_VASPRINTF */
 
-#endif /* __vasprintf_compat_h */
+#endif /* __json_c_vasprintf_compat_h */

--- a/json_object.c
+++ b/json_object.c
@@ -28,7 +28,7 @@
 #include "json_object.h"
 #include "json_object_private.h"
 #include "json_util.h"
-#include "linkhash.h"
+#include "json_c_linkhash.h"
 #include "math_compat.h"
 #include "json_c_printbuf.h"
 #include "snprintf_compat.h"

--- a/json_object.c
+++ b/json_object.c
@@ -22,7 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "arraylist.h"
+#include "json_c_arraylist.h"
 #include "debug.h"
 #include "json_inttypes.h"
 #include "json_object.h"

--- a/json_object.c
+++ b/json_object.c
@@ -12,7 +12,7 @@
 
 #include "config.h"
 
-#include "strerror_override.h"
+#include "json_c_strerror_override.h"
 
 #include <assert.h>
 #include <ctype.h>
@@ -29,10 +29,10 @@
 #include "json_object_private.h"
 #include "json_util.h"
 #include "json_c_linkhash.h"
-#include "math_compat.h"
+#include "json_c_math_compat.h"
 #include "json_c_printbuf.h"
-#include "snprintf_compat.h"
-#include "strdup_compat.h"
+#include "json_c_snprintf_compat.h"
+#include "json_c_strdup_compat.h"
 
 #if SIZEOF_LONG_LONG != SIZEOF_INT64_T
 #error "The long long type isn't 64-bits"

--- a/json_object.c
+++ b/json_object.c
@@ -30,7 +30,7 @@
 #include "json_util.h"
 #include "linkhash.h"
 #include "math_compat.h"
-#include "printbuf.h"
+#include "json_c_printbuf.h"
 #include "snprintf_compat.h"
 #include "strdup_compat.h"
 

--- a/json_object.c
+++ b/json_object.c
@@ -23,7 +23,7 @@
 #include <string.h>
 
 #include "json_c_arraylist.h"
-#include "debug.h"
+#include "json_c_debug.h"
 #include "json_inttypes.h"
 #include "json_object.h"
 #include "json_object_private.h"

--- a/json_object.h
+++ b/json_object.h
@@ -35,7 +35,7 @@
 
 #include "json_inttypes.h"
 #include "json_types.h"
-#include "printbuf.h"
+#include "json_c_printbuf.h"
 
 #include <stddef.h>
 

--- a/json_pointer.c
+++ b/json_pointer.c
@@ -8,7 +8,7 @@
 
 #include "config.h"
 
-#include "strerror_override.h"
+#include "json_c_strerror_override.h"
 
 #include <ctype.h>
 #include <stdarg.h>
@@ -17,8 +17,8 @@
 #include <string.h>
 
 #include "json_pointer.h"
-#include "strdup_compat.h"
-#include "vasprintf_compat.h"
+#include "json_c_strdup_compat.h"
+#include "json_c_vasprintf_compat.h"
 
 /**
  * JavaScript Object Notation (JSON) Pointer

--- a/json_tokener.c
+++ b/json_tokener.c
@@ -26,7 +26,7 @@
 #include <string.h>
 
 #include "json_c_arraylist.h"
-#include "debug.h"
+#include "json_c_debug.h"
 #include "json_inttypes.h"
 #include "json_object.h"
 #include "json_object_private.h"

--- a/json_tokener.c
+++ b/json_tokener.c
@@ -15,7 +15,7 @@
 
 #include "config.h"
 
-#include "math_compat.h"
+#include "json_c_math_compat.h"
 #include <assert.h>
 #include <ctype.h>
 #include <limits.h>
@@ -33,7 +33,7 @@
 #include "json_tokener.h"
 #include "json_util.h"
 #include "json_c_printbuf.h"
-#include "strdup_compat.h"
+#include "json_c_strdup_compat.h"
 
 #ifdef HAVE_LOCALE_H
 #include <locale.h>

--- a/json_tokener.c
+++ b/json_tokener.c
@@ -25,7 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "arraylist.h"
+#include "json_c_arraylist.h"
 #include "debug.h"
 #include "json_inttypes.h"
 #include "json_object.h"

--- a/json_tokener.c
+++ b/json_tokener.c
@@ -32,7 +32,7 @@
 #include "json_object_private.h"
 #include "json_tokener.h"
 #include "json_util.h"
-#include "printbuf.h"
+#include "json_c_printbuf.h"
 #include "strdup_compat.h"
 
 #ifdef HAVE_LOCALE_H

--- a/json_util.c
+++ b/json_util.c
@@ -12,7 +12,7 @@
 #include "config.h"
 #undef realloc
 
-#include "strerror_override.h"
+#include "json_c_strerror_override.h"
 
 #include <ctype.h>
 #include <limits.h>
@@ -48,7 +48,7 @@
 #define open _open
 #endif
 
-#include "snprintf_compat.h"
+#include "json_c_snprintf_compat.h"
 
 #include "json_c_debug.h"
 #include "json_inttypes.h"

--- a/json_util.c
+++ b/json_util.c
@@ -55,7 +55,7 @@
 #include "json_object.h"
 #include "json_tokener.h"
 #include "json_util.h"
-#include "printbuf.h"
+#include "json_c_printbuf.h"
 
 static int _json_object_to_fd(int fd, struct json_object *obj, int flags, const char *filename);
 

--- a/json_util.c
+++ b/json_util.c
@@ -50,7 +50,7 @@
 
 #include "snprintf_compat.h"
 
-#include "debug.h"
+#include "json_c_debug.h"
 #include "json_inttypes.h"
 #include "json_object.h"
 #include "json_tokener.h"

--- a/json_visit.c
+++ b/json_visit.c
@@ -11,7 +11,7 @@
 #include "json_inttypes.h"
 #include "json_object.h"
 #include "json_visit.h"
-#include "linkhash.h"
+#include "json_c_linkhash.h"
 
 static int _json_c_visit(json_object *jso, json_object *parent_jso, const char *jso_key,
                          size_t *jso_index, json_c_visit_userfunc *userfunc, void *userarg);

--- a/printbuf.c
+++ b/printbuf.c
@@ -25,7 +25,7 @@
 #error Not enough var arg support!
 #endif /* HAVE_STDARG_H */
 
-#include "debug.h"
+#include "json_c_debug.h"
 #include "printbuf.h"
 #include "snprintf_compat.h"
 #include "vasprintf_compat.h"

--- a/tests/test_deep_copy.c
+++ b/tests/test_deep_copy.c
@@ -10,7 +10,7 @@
 #include <time.h>
 
 #include "json.h"
-#include "printbuf.h"
+#include "json_c_printbuf.h"
 
 static void do_benchmark(json_object *src1);
 

--- a/tests/test_json_pointer.c
+++ b/tests/test_json_pointer.c
@@ -1,5 +1,5 @@
-#include "strerror_override.h"
-#include "strerror_override_private.h"
+#include "json_c_strerror_override.h"
+#include "json_c_strerror_override_private.h"
 #ifdef NDEBUG
 #undef NDEBUG
 #endif

--- a/tests/test_locale.c
+++ b/tests/test_locale.c
@@ -7,7 +7,7 @@
 #include "config.h"
 #include "json.h"
 #include "json_tokener.h"
-#include "snprintf_compat.h"
+#include "json_c_snprintf_compat.h"
 
 #ifdef HAVE_LOCALE_H
 #include <locale.h>

--- a/tests/test_printbuf.c
+++ b/tests/test_printbuf.c
@@ -6,7 +6,7 @@
 #include <string.h>
 
 #include "json_c_debug.h"
-#include "printbuf.h"
+#include "json_c_printbuf.h"
 
 static void test_basic_printbuf_memset(void);
 static void test_printbuf_memset_length(void);

--- a/tests/test_printbuf.c
+++ b/tests/test_printbuf.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "debug.h"
+#include "json_c_debug.h"
 #include "printbuf.h"
 
 static void test_basic_printbuf_memset(void);

--- a/tests/test_set_serializer.c
+++ b/tests/test_set_serializer.c
@@ -3,7 +3,7 @@
 #include <string.h>
 
 #include "json.h"
-#include "printbuf.h"
+#include "json_c_printbuf.h"
 
 struct myinfo
 {

--- a/tests/test_util_file.c
+++ b/tests/test_util_file.c
@@ -1,5 +1,5 @@
-#include "strerror_override.h"
-#include "strerror_override_private.h"
+#include "json_c_strerror_override.h"
+#include "json_c_strerror_override_private.h"
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <io.h>
@@ -20,7 +20,7 @@
 
 #include "json.h"
 #include "json_util.h"
-#include "snprintf_compat.h"
+#include "json_c_snprintf_compat.h"
 
 static void test_read_valid_with_fd(const char *testdir);
 static void test_read_valid_nested_with_fd(const char *testdir);


### PR DESCRIPTION
Installing this file will lead to clashes with applications, that link against json-c and include their own build-time config.h.
Anyways, that particular header file is not needed to build and link against json-c.

Likewise any public headers with generic names should be prefixed with `json_c` to avoid possible undesired clashes.

***

Please backport these commits to 0.14 as the current release may break building any apllication randomly for no obvious reason for this header file being present.