### PR TITLE
Store the hashValue to avoid repeating the hash calculation during the hash resize.

### DIFF
--- a/linkhash.c
+++ b/linkhash.c
@@ -540,7 +540,7 @@ int lh_table_resize(struct lh_table *t, int new_size)
 
 	for (ent = t->head; ent != NULL; ent = ent->next)
 	{
-		unsigned long h = lh_get_hash(new_t, ent->k);
+		unsigned long h = ent->hash;
 		unsigned int opts = 0;
 		if (ent->k_is_constant)
 			opts = JSON_C_OBJECT_KEY_IS_CONSTANT;
@@ -581,7 +581,7 @@ int lh_table_insert_w_hash(struct lh_table *t, const void *k, const void *v, con
 		if (lh_table_resize(t, t->size * 2) != 0)
 			return -1;
 
-	n = h % t->size;
+	n = h & (t->size - 1);
 
 	while (1)
 	{
@@ -591,6 +591,7 @@ int lh_table_insert_w_hash(struct lh_table *t, const void *k, const void *v, con
 			n = 0;
 	}
 
+	t->table[n].hash = h;
 	t->table[n].k = k;
 	t->table[n].k_is_constant = (opts & JSON_C_OBJECT_KEY_IS_CONSTANT);
 	t->table[n].v = v;

--- a/linkhash.h
+++ b/linkhash.h
@@ -84,15 +84,20 @@ typedef int(lh_equal_fn)(const void *k1, const void *k2);
  */
 struct lh_entry
 {
+
 	/**
-	 * The key.  Use lh_entry_k() instead of accessing this directly.
+	 *The hash. Use to determine the position of the entry in the array.
 	 */
-	const void *k;
+	uint32_t hash;
 	/**
 	 * A flag for users of linkhash to know whether or not they
 	 * need to free k.
 	 */
 	int k_is_constant;
+	/**
+	 * The key.  Use lh_entry_k() instead of accessing this directly.
+	 */
+	const void *k;
 	/**
 	 * The value.  Use lh_entry_v() instead of accessing this directly.
 	 */


### PR DESCRIPTION
Discuss:
Cache the hash value in lh_entry. This value is used directly during hash resize to calculate the index of the data in hash table. This method will reduce the times of hash calculations. The improving effect of the parse speed is more obvious in the case of multiple objects. But this method will add 4 bytes overhead for every lh_entry in 32-bit systems.

|json file|ave_time before/ms|ave_time after/ms|optimization ratio/%|
| ---- | ---- | ---- | ---- |
|[twitter.json](https://github.com/dota17/nativejson-benchmark/blob/master/data/twitter.json)|11.66|10.53|9.69|
|jeopardy_50m.json|964|920|4.5|
|[citm_catalog_1.6m.json](https://github.com/dota17/nativejson-benchmark/blob/master/data/citm_catalog.json)|28.82|27|6.3|
