### PR TITLE
Fix segmentation fault in CPUID check

### DIFF
--- a/random_seed.c
+++ b/random_seed.c
@@ -26,19 +26,8 @@
 static void do_cpuid(int regs[], int h)
 {
 	/* clang-format off */
-    __asm__ __volatile__(
-#if defined __x86_64__
-                         "pushq %%rbx;\n"
-#else
-                         "pushl %%ebx;\n"
-#endif
-                         "cpuid;\n"
-#if defined __x86_64__
-                         "popq %%rbx;\n"
-#else
-                         "popl %%ebx;\n"
-#endif
-                         : "=a"(regs[0]), [ebx] "=r"(regs[1]), "=c"(regs[2]), "=d"(regs[3])
+    __asm__ __volatile__("cpuid"
+                         : "=a"(regs[0]), "=b"(regs[1]), "=c"(regs[2]), "=d"(regs[3])
                          : "a"(h));
 	/* clang-format on */
 }


### PR DESCRIPTION
The current CPUID check seems to be reliant on the state of registers at call-time (...or something like that?), since it occasionally segfaults. Here's an example of it in a simplified context:

```c
#include <stdio.h>

static void do_cpuid(int regs[], int h)
{
	/* clang-format off */
    __asm__ __volatile__(
#if defined __x86_64__
                         "pushq %%rbx;\n"
#else
                         "pushl %%ebx;\n"
#endif
                         "cpuid;\n"
#if defined __x86_64__
                         "popq %%rbx;\n"
#else
                         "popl %%ebx;\n"
#endif
                         : "=a"(regs[0]), [ebx] "=r"(regs[1]), "=c"(regs[2]), "=d"(regs[3])
                         : "a"(h));
	/* clang-format on */
}

static int has_rdrand(void)
{
    // CPUID.01H:ECX.RDRAND[bit 30] == 1
    int regs[4];
    do_cpuid(regs, 1);
    return (regs[2] & (1 << 30)) != 0;
}

static int get_rdrand_seed(void)
{
	int _eax;
	// rdrand eax
	/* clang-format off */
	__asm__ __volatile__("1: .byte 0x0F\n"
	                    "   .byte 0xC7\n"
	                    "   .byte 0xF0\n"
	                    "   jnc 1b;\n"
	                    : "=a" (_eax));
	/* clang-format on */
	return _eax;
}

int main(void) { 
	printf("HAS RDRAND: %d\n", has_rdrand());
	for (int i = 0; i < 10; i++) {
		printf("%d\n", get_rdrand_seed());
	}
	return 0;
}
```

Compiling and running, the result is:

```
$ gcc foo.c -g -o foo && ./foo
Segmentation fault
```

Poking in GDB,

```
Program received signal SIGSEGV, Segmentation fault.
0x0000555555555165 in do_cpuid (regs=0x0, h=1) at foo.c:6
6	   __asm__ __volatile__(
(gdb) disas 0x0000555555555150,0x0000555555555170
Dump of assembler code from 0x555555555150 to 0x555555555170:
   0x0000555555555150 <do_cpuid+27>:	mov    -0x8(%rbp),%rax
   0x0000555555555154 <do_cpuid+31>:	lea    0xc(%rax),%r8
   0x0000555555555158 <do_cpuid+35>:	mov    -0xc(%rbp),%eax
   0x000055555555515b <do_cpuid+38>:	push   %rbx
   0x000055555555515c <do_cpuid+39>:	cpuid  
   0x000055555555515e <do_cpuid+41>:	pop    %rbx
   0x000055555555515f <do_cpuid+42>:	mov    %eax,%edi
   0x0000555555555161 <do_cpuid+44>:	mov    -0x8(%rbp),%rax
=> 0x0000555555555165 <do_cpuid+48>:	mov    %edi,(%rax)
   0x0000555555555167 <do_cpuid+50>:	mov    %esi,(%r10)
   0x000055555555516a <do_cpuid+53>:	mov    %ecx,(%r9)
   0x000055555555516d <do_cpuid+56>:	mov    %edx,(%r8)
```

I'm not sure what the pushing in the existing code tries to accomplish, but replacing it with something like [what the Linux kernel](http://lxr.linux.no/#linux+v2.6.39/arch/x86/include/asm/processor.h#L173) and [this thread](https://gcc.gnu.org/legacy-ml/gcc-help/2015-08/msg00089.html) do resolves the issue.