### PR TITLE
Prevent out of boundary write on malicious input

### DIFF
--- a/arraylist.c
+++ b/arraylist.c
@@ -136,6 +136,9 @@ int array_list_del_idx(struct array_list *arr, size_t idx, size_t count)
 {
 	size_t i, stop;
 
+	/* Avoid overflow in calculation with large indices. */
+	if (idx > SIZE_T_MAX - count)
+		return -1;
 	stop = idx + count;
 	if (idx >= arr->length || stop > arr->length)
 		return -1;

--- a/linkhash.c
+++ b/linkhash.c
@@ -580,9 +580,12 @@ int lh_table_insert_w_hash(struct lh_table *t, const void *k, const void *v, con
 {
 	unsigned long n;
 
-	if (t->count >= t->size * LH_LOAD_FACTOR)
-		if (lh_table_resize(t, t->size * 2) != 0)
+	if (t->count >= t->size * LH_LOAD_FACTOR) {
+		/* Avoid signed integer overflow with large tables. */
+		int new_size = INT_MAX / 2 < t->size ? t->size * 2 : INT_MAX;
+		if (t->size == INT_MAX || lh_table_resize(t, new_size) != 0)
 			return -1;
+	}
 
 	n = h % t->size;
 

--- a/linkhash.c
+++ b/linkhash.c
@@ -12,6 +12,7 @@
 
 #include "config.h"
 
+#include <assert.h>
 #include <limits.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -499,6 +500,8 @@ struct lh_table *lh_table_new(int size, lh_entry_free_fn *free_fn, lh_hash_fn *h
 	int i;
 	struct lh_table *t;
 
+	/* Allocate space for elements to avoid divisions by zero. */
+	assert(size > 0);
 	t = (struct lh_table *)calloc(1, sizeof(struct lh_table));
 	if (!t)
 		return NULL;

--- a/printbuf.c
+++ b/printbuf.c
@@ -15,6 +15,7 @@
 
 #include "config.h"
 
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -65,10 +66,16 @@ static int printbuf_extend(struct printbuf *p, int min_size)
 
 	if (p->size >= min_size)
 		return 0;
-
-	new_size = p->size * 2;
-	if (new_size < min_size + 8)
+	/* Prevent signed integer overflows with large buffers. */
+	if (min_size > INT_MAX - 8)
+		return -1;
+	if (p->size > INT_MAX / 2)
 		new_size = min_size + 8;
+	else {
+		new_size = p->size * 2;
+		if (new_size < min_size + 8)
+			new_size = min_size + 8;
+	}
 #ifdef PRINTBUF_DEBUG
 	MC_DEBUG("printbuf_memappend: realloc "
 	         "bpos=%d min_size=%d old_size=%d new_size=%d\n",
@@ -83,6 +90,9 @@ static int printbuf_extend(struct printbuf *p, int min_size)
 
 int printbuf_memappend(struct printbuf *p, const char *buf, int size)
 {
+	/* Prevent signed integer overflows with large buffers. */
+	if (size > INT_MAX - p->bpos - 1)
+		return -1;
 	if (p->size <= p->bpos + size + 1)
 	{
 		if (printbuf_extend(p, p->bpos + size + 1) < 0)
@@ -100,6 +110,9 @@ int printbuf_memset(struct printbuf *pb, int offset, int charvalue, int len)
 
 	if (offset == -1)
 		offset = pb->bpos;
+	/* Prevent signed integer overflows with large buffers. */
+	if (len > INT_MAX - offset)
+		return -1;
 	size_needed = offset + len;
 	if (pb->size < size_needed)
 	{


### PR DESCRIPTION
I have discovered a way to trigger an out of boundary write while parsing a huge json file through a malicious input source. It can be triggered if an attacker has control over the input stream or if a huge load during filesystem operations can be triggered.

Preparation:
``$ dd if=/dev/zero of=poc.json bs=1 count=1 seek=2147483647``

Code to exploit:
```
#include <json-c/json_util.h>
#include <unistd.h>
int main() {
  json_object_from_fd(STDIN_FILENO);
  return 0;
}
```

Proof of Concept:
``(dd if=poc.json bs=4096; sleep 1; dd if=test.json bs=10) 2>/dev/null | ./test``

Explanation:
The problem manifests itself in printbuf_memappend. On properly crafted values, p->bpos + size + 1 can overflow, which leads to the assumption that p->size is still large enough. In normal circumstances, this does not happen with json_object_from_fd due to its buffer size leading to proper detection. But if the parsed buffer chunk length is not a power of 2 (sleep 1 and bs=10 triggers this in my proof of concept), this overflow can be abused by an attacker to write past the memory boundary of p->buf.

My example simply crashes the program eventually. A proper attack can be controled in a way to not crash the system but simply write a few attacker controlled bytes outside the allocated area, allowing more sophisticated attacks against real world programs.