### PR TITLE
use unsigned types for sizes in lh_table and entries

### DIFF
--- a/linkhash.h
+++ b/linkhash.h
@@ -18,7 +18,6 @@
  */
 #ifndef _linkhash_h_
 #define _linkhash_h_
-
 #include "json_object.h"
 
 #ifdef __cplusplus
@@ -92,7 +91,7 @@ struct lh_entry
 	 * A flag for users of linkhash to know whether or not they
 	 * need to free k.
 	 */
-	int k_is_constant;
+	unsigned int k_is_constant;
 	/**
 	 * The value.  Use lh_entry_v() instead of accessing this directly.
 	 */
@@ -115,11 +114,11 @@ struct lh_table
 	/**
 	 * Size of our hash.
 	 */
-	int size;
+	size_t size;
 	/**
 	 * Numbers of entries.
 	 */
-	int count;
+	unsigned int count;
 
 	/**
 	 * The first entry.


### PR DESCRIPTION
CVE-2020-12762 was a result of integer overflow on types that don't really need to be signed at all, this patch changes them to unsigned types, avoiding similar problems in the future