### PR TITLE
Add an option to disable the use of thread-local storage.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ option(ENABLE_RDRAND                "Enable RDRAND Hardware RNG Hash Seed"      
 option(ENABLE_THREADING             "Enable partial threading support."             OFF)
 option(DISABLE_WERROR               "Avoid treating compiler warnings as fatal errors"    OFF)
 option(DISABLE_BSYMBOLIC            "Avoid linking with -Bsymbolic-function"   OFF)
+option(DISABLE_THREAD_LOCAL_STORAGE "Disable Thread-Local Storage (HAVE___THREAD)"   OFF)
 
 if (UNIX OR MINGW OR CYGWIN)
     list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
@@ -217,14 +218,16 @@ check_c_source_compiles(
   "int main() { int i, x = 0; i = __sync_add_and_fetch(&x,1); return x; }"
   HAVE_ATOMIC_BUILTINS)
 
-check_c_source_compiles(
-  "__thread int x = 0; int main() { return 0; }"
-  HAVE___THREAD)
+if (NOT DISABLE_THREAD_LOCAL_STORAGE)
+  check_c_source_compiles(
+    "__thread int x = 0; int main() { return 0; }"
+    HAVE___THREAD)
 
-if (HAVE___THREAD)
-    set(SPEC___THREAD __thread)
-elseif (MSVC)
-    set(SPEC___THREAD __declspec(thread))
+  if (HAVE___THREAD)
+      set(SPEC___THREAD __thread)
+  elseif (MSVC)
+      set(SPEC___THREAD __declspec(thread))
+  endif()
 endif()
 
 # Hardware random number is not available on Windows? Says, config.h.win32. Best to preserve compatibility.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,11 +83,11 @@ COMMAND make package_source
 )
 
 # Enable or disable features. By default, all features are turned off.
-option(ENABLE_RDRAND                "Enable RDRAND Hardware RNG Hash Seed"          OFF)
-option(ENABLE_THREADING             "Enable partial threading support."             OFF)
-option(DISABLE_WERROR               "Avoid treating compiler warnings as fatal errors"    OFF)
-option(DISABLE_BSYMBOLIC            "Avoid linking with -Bsymbolic-function"   OFF)
-option(DISABLE_THREAD_LOCAL_STORAGE "Disable Thread-Local Storage (HAVE___THREAD)"   OFF)
+option(DISABLE_BSYMBOLIC              "Avoid linking with -Bsymbolic-function."               OFF)
+option(DISABLE_THREAD_LOCAL_STORAGE   "Disable using Thread-Local Storage (HAVE___THREAD)."   OFF)
+option(DISABLE_WERROR                 "Avoid treating compiler warnings as fatal errors."     OFF)
+option(ENABLE_RDRAND                  "Enable RDRAND Hardware RNG Hash Seed."                 OFF)
+option(ENABLE_THREADING               "Enable partial threading support."                     OFF)
 
 if (UNIX OR MINGW OR CYGWIN)
     list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)

--- a/README.md
+++ b/README.md
@@ -93,16 +93,17 @@ CMake Options <a name="CMake"></a>
 The json-c library is built with [CMake](https://cmake.org/cmake-tutorial/),
 which can take a few options.
 
-Variable             | Type   | Description
----------------------|--------|--------------
-CMAKE_INSTALL_PREFIX | String | The install location.
-CMAKE_BUILD_TYPE     | String | Defaults to "debug"
-BUILD_SHARED_LIBS    | Bool   | The default build generates a dynamic (dll/so) library.  Set this to OFF to create a static library only.
-BUILD_STATIC_LIBS    | Bool   | The default build generates a static (lib/a) library.  Set this to OFF to create a shared library only.
-ENABLE_RDRAND        | Bool   | Enable RDRAND Hardware RNG Hash Seed
-ENABLE_THREADING     | Bool   | Enable partial threading support
-DISABLE_WERROR       | Bool   | Disable use of -Werror
-DISABLE_BSYMBOLIC    | Bool   | Disable use of -Bsymbolic-functions
+Variable                     | Type   | Description
+-----------------------------|--------|--------------
+CMAKE_INSTALL_PREFIX         | String | The install location.
+CMAKE_BUILD_TYPE             | String | Defaults to "debug".
+BUILD_SHARED_LIBS            | Bool   | The default build generates a dynamic (dll/so) library.  Set this to OFF to create a static library only.
+BUILD_STATIC_LIBS            | Bool   | The default build generates a static (lib/a) library.  Set this to OFF to create a shared library only.
+DISABLE_BSYMBOLIC            | Bool   | Disable use of -Bsymbolic-functions.
+DISABLE_THREAD_LOCAL_STORAGE | Bool   | Disable use of Thread-Local Storage (HAVE___THREAD).
+DISABLE_WERROR               | Bool   | Disable use of -Werror.
+ENABLE_RDRAND                | Bool   | Enable RDRAND Hardware RNG Hash Seed.
+ENABLE_THREADING             | Bool   | Enable partial threading support.
 
 Pass these options as `-D` on CMake's command-line.
 

--- a/tests/test_double_serializer.c
+++ b/tests/test_double_serializer.c
@@ -59,6 +59,7 @@ int main()
 #else
 	// Just fake it up, so the output matches.
 	printf("obj.to_string(with thread format)=%s\n", "T0.52X");
+	printf("obj.to_string(long thread format)=%s\n", "Ttttttttttttt0.52xxxxxxxxxxxxxxxxxxX");
 	printf("obj.to_string(back to global format)=%s\n", "x0.524y");
 #endif
 	if (json_c_set_serialization_double_format(NULL, JSON_C_OPTION_GLOBAL) < 0)


### PR DESCRIPTION
Using thread-local storage may not be desired in all environments and/or use-cases, thus there should be an option to disable its use on purpose.

Fixes #451.