### PR TITLE
CMake: Fix out-of-tree build for Doxygen documentation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,12 +368,13 @@ option(BUILD_DOCUMENTATION "Create and install the HTML based API documentation(
 
 if (DOXYGEN_FOUND)
 
-	add_custom_target(doc
-	COMMAND ${DOXYGEN_EXECUTABLE} ${PROJECT_SOURCE_DIR}/Doxyfile
-		WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+	configure_file(${PROJECT_SOURCE_DIR}/Doxyfile.in
+	  ${PROJECT_BINARY_DIR}/Doxyfile)
+	message(STATUS "Written ${PROJECT_BINARY_DIR}/Doxyfile")
 
-	# request to configure the file
-	configure_file(Doxyfile Doxyfile)
+	add_custom_target(doc
+	COMMAND ${DOXYGEN_EXECUTABLE} ${PROJECT_BINARY_DIR}/Doxyfile
+		WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
 else (DOXYGEN_FOUND)
 	message("Warning: doxygen not found, the 'doc' target will not be included")

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -38,7 +38,7 @@ PROJECT_NAME           = json-c
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.14.99
+PROJECT_NUMBER         = @PROJECT_VERSION@
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -753,7 +753,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  =
+INPUT                  = @CMAKE_SOURCE_DIR@ @CMAKE_BINARY_DIR@
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
This allows to build the Doxygen documentation out-of-tree properly.