### PR TITLE
Compat fixes

### DIFF
--- a/random_seed.c
+++ b/random_seed.c
@@ -194,27 +194,35 @@ static int get_dev_random_seed(void)
 #pragma comment(lib, "advapi32.lib")
 #endif
 
+static int get_time_seed(void);
+
 static int get_cryptgenrandom_seed(void)
 {
 	HCRYPTPROV hProvider = 0;
+	DWORD dwFlags = CRYPT_VERIFYCONTEXT;
 	int r;
 
 	DEBUG_SEED("get_cryptgenrandom_seed");
 
-	if (!CryptAcquireContextW(&hProvider, 0, 0, PROV_RSA_FULL,
-	                          CRYPT_VERIFYCONTEXT | CRYPT_SILENT))
-	{
-		fprintf(stderr, "error CryptAcquireContextW");
-		exit(1);
-	}
+	/* WinNT 4 and Win98 do no support CRYPT_SILENT */
+	if (LOBYTE(LOWORD(GetVersion())) > 4)
+		dwFlags |= CRYPT_SILENT;
 
-	if (!CryptGenRandom(hProvider, sizeof(r), (BYTE *)&r))
+	if (!CryptAcquireContextA(&hProvider, 0, 0, PROV_RSA_FULL, dwFlags))
 	{
-		fprintf(stderr, "error CryptGenRandom");
-		exit(1);
+		fprintf(stderr, "error CryptAcquireContextA 0x%08x", GetLastError());
+		r = get_time_seed();
 	}
-
-	CryptReleaseContext(hProvider, 0);
+	else
+	{
+		BOOL ret = CryptGenRandom(hProvider, sizeof(r), (BYTE*)&r);
+		CryptReleaseContext(hProvider, 0);
+		if (!ret)
+		{
+			fprintf(stderr, "error CryptGenRandom 0x%08x", GetLastError());
+			r = get_time_seed();
+		}
+	}
 
 	return r;
 }


### PR DESCRIPTION
there is no need to call CryptAcquireContextW because two string parameters are NULL
CryptAcquireContextW does not work on Win98, and CRYPT_SILENT flags is not supported on WInNT4 and Win98x, any info about WIn2k?

I'm returning the fallback function, if you don't like it it can be reverted, but anyway is a bad pratice to call exit() inside a library