### PR TITLE
Cast to unsigned char instead of int when calling tolower (Fixes #645)

### DIFF
--- a/json_tokener.c
+++ b/json_tokener.c
@@ -430,7 +430,7 @@ struct json_object *json_tokener_parse_ex(struct json_tokener *tok, const char *
 			{
 				char inf_char = *str;
 				if (!(tok->flags & JSON_TOKENER_STRICT))
-					inf_char = tolower((int)*str);
+					inf_char = tolower((unsigned char)*str);
 				if (inf_char != _json_inf_str[tok->st_pos])
 				{
 					tok->err = json_tokener_error_parse_unexpected;


### PR DESCRIPTION
`tolower` expects an `unsigned char` or the special value `EOF`.