### PR TITLE
Make the documentation build reproducibly

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -152,7 +152,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        =
+STRIP_FROM_PATH        = @CMAKE_SOURCE_DIR@
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/) I noticed that `json-c` could not be built reproducibly.

This is because it used the full, absolute path name as a (sanitised) input to a filename, resulting in some binary package containing, for example:

```
/usr/share/doc/libjson-c-dev/html/md__build_1st_json-c-0_815_issues_closed_for_0_813.html
                                        ^^^^^^^^^^^^^^^^^^^^^^
```

or

```
/usr/share/doc/libjson-c-dev/html/md__build_2_json-c-0_815_2nd_issues_closed_for_0_813.html
                                        ^^^^^^^^^^^^^^^^^^^^^^^^
```

These differing values are based on the path in which `json-c` is built. This was originally filed in Debian as [#966657](https://bugs.debian.org/966657).