### PR TITLE
fix json_object_get_boolean() to behave like documented

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -702,7 +702,8 @@ json_bool json_object_get_boolean(const struct json_object *jso)
 		}
 	case json_type_double: return (JC_DOUBLE_C(jso)->c_double != 0);
 	case json_type_string: return (JC_STRING_C(jso)->len != 0);
-	default: return 0;
+	case json_type_null: return 0;
+	default: return 1;
 	}
 }
 


### PR DESCRIPTION
Fixes #658 

`json_object_get_boolean()` must return true for objects and arrays

This boils down to: any object type not checked specifically in the switch statement should return 1, not 0.

I know that `null`values are usually represented as having no object at all, which is checked right after the entry into json_object_get_boolean().
However as I am not 100% sure an object having explicit json_type_null type set is impossible to exist under any circumstances, I added a switch case for that, too.
