### PR TITLE
Prevent signed overflow in get_time_seed

### DIFF
--- a/random_seed.c
+++ b/random_seed.c
@@ -305,7 +305,7 @@ static int get_time_seed(void)
 {
 	DEBUG_SEED("get_time_seed");
 
-	return (int)time(NULL) * 433494437;
+	return (unsigned)time(NULL) * 433494437;
 }
 
 /* json_c_get_random_seed */


### PR DESCRIPTION
Casting time(2) return value to int and multiplying the result with
such a constant will definitely lead to a signed overflow by this day.

Since signed overflows are undefined behaviour in C, avoid this.

Casting to unsigned is more than enough since the upper bits of a
64 bit time_t value will be removed with the int conversion anyway.