### PR TITLE
Handle more allocation failures in json_tokener* functions

### DIFF
--- a/json_tokener.c
+++ b/json_tokener.c
@@ -134,6 +134,12 @@ struct json_tokener *json_tokener_new_ex(int depth)
 		return NULL;
 	}
 	tok->pb = printbuf_new();
+	if (!tok->pb)
+	{
+		free(tok);
+		free(tok->stack);
+		return NULL;
+	}
 	tok->max_depth = depth;
 	json_tokener_reset(tok);
 	return tok;


### PR DESCRIPTION
The allocation of printbuffer could fail. Also avoid strdup for
setlocale return value to prevent allocation issues in the first place.