### PR TITLE
Fixed test1 regression.

### DIFF
--- a/tests/test1.c
+++ b/tests/test1.c
@@ -5,6 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "config.h"
+
 #include "json.h"
 #include "parse_flags.h"
 


### PR DESCRIPTION
SIZEOF_SIZE_T might be only defined in config.h.

Include config.h for these systems to pass tests which are only
supposed to be run on 32 bit systems.

Fixes issue #666.