### PR TITLE
Let json-c be used with obsolete compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,11 +143,14 @@ check_include_file(sys/random.h     HAVE_SYS_RANDOM_H)
 check_include_file(sys/stat.h       HAVE_SYS_STAT_H)
 check_include_file(xlocale.h        HAVE_XLOCALE_H)
 
+# Set json-c specific vars to stamp into json_config.h
+# in a way that hopefully won't conflict with other
+# projects that use json-c.
 if (HAVE_INTTYPES_H)
-	# Set a json-c specific var to stamp into json_config.h
-	# in a way that hopefully won't conflict with other
-	# projects that use json-c.
-    set(JSON_C_HAVE_INTTYPES_H 1)
+	set(JSON_C_HAVE_INTTYPES_H 1)
+endif()
+if (HAVE_STDINT_H)
+	set(JSON_C_HAVE_STDINT_H 1)
 endif()
 
 check_symbol_exists(_isnan          "float.h" HAVE_DECL__ISNAN)

--- a/cmake/json_config.h.in
+++ b/cmake/json_config.h.in
@@ -1,2 +1,5 @@
 /* Define to 1 if you have the <inttypes.h> header file. */
 #cmakedefine JSON_C_HAVE_INTTYPES_H @JSON_C_HAVE_INTTYPES_H@
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#cmakedefine JSON_C_HAVE_STDINT_H @JSON_C_HAVE_STDINT_H@

--- a/json_inttypes.h
+++ b/json_inttypes.h
@@ -13,7 +13,15 @@
 #include <inttypes.h>
 
 #else
+#ifdef JSON_C_HAVE_STDINT_H
 #include <stdint.h>
+#else
+/* Really only valid for old MS compilers, VS2008 and earlier: */
+typedef __int32 int32_t;
+typedef unsigned __int32 uint32_t;
+typedef __int64 int64_t;
+typedef unsigned __int64 uint64_t;
+#endif
 
 #define PRId64 "I64d"
 #define SCNd64 "I64d"


### PR DESCRIPTION
adding stdint typedefs

and if you like to, you could add

```c
#if defined (_MSC_VER) && _MSC_VER < 1600
#define MISSING_STDINT_H
#endif
```

up front...

Feel free to close this PR if somewhere it is explicit said that the compiled json-c library may not be used with that old compilers.