### PR TITLE
To avoid target exe file export JSON functions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,10 @@ include(CMakePackageConfigHelpers)
 option(BUILD_SHARED_LIBS  "Default to building shared libraries" ON)
 option(BUILD_STATIC_LIBS  "Default to building static libraries" ON)
 
+if (BUILD_SHARED_LIBS)
+    add_definitions(-D JSON_C_DLL)
+endif()
+
 # Generate a release merge and test it to verify the correctness of republishing the package.
 ADD_CUSTOM_TARGET(distcheck
 COMMAND make package_source

--- a/debug.h
+++ b/debug.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 #ifndef JSON_EXPORT
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(JSON_C_DLL)
 #define JSON_EXPORT __declspec(dllexport)
 #else
 #define JSON_EXPORT extern

--- a/json_c_version.h
+++ b/json_c_version.h
@@ -24,7 +24,7 @@ extern "C" {
 #define JSON_C_VERSION "0.15.99"
 
 #ifndef JSON_EXPORT
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(JSON_C_DLL)
 #define JSON_EXPORT __declspec(dllexport)
 #else
 #define JSON_EXPORT extern

--- a/json_types.h
+++ b/json_types.h
@@ -18,7 +18,7 @@ extern "C" {
 #endif
 
 #ifndef JSON_EXPORT
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(JSON_C_DLL)
 #define JSON_EXPORT __declspec(dllexport)
 #else
 #define JSON_EXPORT extern

--- a/printbuf.h
+++ b/printbuf.h
@@ -24,7 +24,7 @@
 #define _printbuf_h_
 
 #ifndef JSON_EXPORT
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(JSON_C_DLL)
 #define JSON_EXPORT __declspec(dllexport)
 #else
 #define JSON_EXPORT extern


### PR DESCRIPTION
Add JSON_C_DLL flag to avoid target exe file export JSON functions.

![image](https://user-images.githubusercontent.com/30760636/116051608-5cb64680-a6ab-11eb-948c-39277ac7637f.png)
