### PR TITLE
Fix unused variable for Win32 build in random_seed.c

### DIFF
--- a/random_seed.c
+++ b/random_seed.c
@@ -271,7 +271,6 @@ static int get_cryptgenrandom_seed(int *seed)
 {
 	HCRYPTPROV hProvider = 0;
 	DWORD dwFlags = CRYPT_VERIFYCONTEXT;
-	int r;
 
 	DEBUG_SEED("get_cryptgenrandom_seed");
 


### PR DESCRIPTION
CMake Release configuration add the `-Werror` flag, which fails the compilation if there any warning. There is an only one - unused variable.
Please let compilations succeed with Release configuration.

Build logs:
```bash
user@buildhost MINGW64 ~/json-c
$ mkdir build && cd $_

user@buildhost MINGW64 ~/json-c/build
$ cmake .. -G"MSYS Makefiles" -DCMAKE_BUILD_TYPE=Release
-- The C compiler identification is GNU 10.2.0
-- Check for working C compiler: C:/msys64/mingw64/bin/gcc.exe
-- Check for working C compiler: C:/msys64/mingw64/bin/gcc.exe - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Looking for sys/resource.h
-- Looking for sys/resource.h - not found
-- Wrote C:/msys64/home/user/json-c/build/apps_config.h
-- Looking for fcntl.h
-- Looking for fcntl.h - found
-- Looking for inttypes.h
-- Looking for inttypes.h - found
-- Looking for stdarg.h
-- Looking for stdarg.h - found
-- Looking for strings.h
-- Looking for strings.h - found
-- Looking for string.h
-- Looking for string.h - found
-- Looking for syslog.h
-- Looking for syslog.h - not found
-- Looking for 4 include files stdlib.h, ..., float.h
-- Looking for 4 include files stdlib.h, ..., float.h - found
-- Looking for unistd.h
-- Looking for unistd.h - found
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for dlfcn.h
-- Looking for dlfcn.h - not found
-- Looking for endian.h
-- Looking for endian.h - not found
-- Looking for limits.h
-- Looking for limits.h - found
-- Looking for locale.h
-- Looking for locale.h - found
-- Looking for memory.h
-- Looking for memory.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stdlib.h
-- Looking for stdlib.h - found
-- Looking for sys/cdefs.h
-- Looking for sys/cdefs.h - found
-- Looking for sys/param.h
-- Looking for sys/param.h - found
-- Looking for sys/random.h
-- Looking for sys/random.h - not found
-- Looking for sys/stat.h
-- Looking for sys/stat.h - found
-- Looking for xlocale.h
-- Looking for xlocale.h - not found
-- Looking for _isnan
-- Looking for _isnan - found
-- Looking for _finite
-- Looking for _finite - found
-- Looking for INFINITY
-- Looking for INFINITY - found
-- Looking for isinf
-- Looking for isinf - found
-- Looking for isnan
-- Looking for isnan - found
-- Looking for nan
-- Looking for nan - found
-- Looking for _doprnt
-- Looking for _doprnt - not found
-- Looking for snprintf
-- Looking for snprintf - found
-- Looking for vasprintf
-- Looking for vasprintf - found
-- Looking for vsnprintf
-- Looking for vsnprintf - found
-- Looking for vprintf
-- Looking for vprintf - found
-- Looking for arc4random
-- Looking for arc4random - not found
-- Looking for bsd/stdlib.h
-- Looking for bsd/stdlib.h - not found
-- Looking for open
-- Looking for open - found
-- Looking for realloc
-- Looking for realloc - found
-- Looking for setlocale
-- Looking for setlocale - found
-- Looking for uselocale
-- Looking for uselocale - not found
-- Looking for strcasecmp
-- Looking for strcasecmp - found
-- Looking for strncasecmp
-- Looking for strncasecmp - found
-- Looking for strdup
-- Looking for strdup - found
-- Looking for strerror
-- Looking for strerror - found
-- Looking for strtoll
-- Looking for strtoll - found
-- Looking for strtoull
-- Looking for strtoull - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of int
-- Check size of int - done
-- Check size of int64_t
-- Check size of int64_t - done
-- Check size of long
-- Check size of long - done
-- Check size of long long
-- Check size of long long - done
-- Check size of size_t
-- Check size of size_t - done
-- Check size of ssize_t
-- Check size of ssize_t - done
-- Performing Test HAS_GNU_WARNING_LONG
-- Performing Test HAS_GNU_WARNING_LONG - Failed
-- Performing Test HAVE_ATOMIC_BUILTINS
-- Performing Test HAVE_ATOMIC_BUILTINS - Success
-- Performing Test HAVE___THREAD
-- Performing Test HAVE___THREAD - Success
-- Wrote C:/msys64/home/user/json-c/build/config.h
-- Wrote C:/msys64/home/user/json-c/build/json_config.h
-- Performing Test REENTRANT_WORKS
-- Performing Test REENTRANT_WORKS - Success
-- Performing Test BSYMBOLIC_WORKS
-- Performing Test BSYMBOLIC_WORKS - Success
-- Performing Test VERSION_SCRIPT_WORKS
-- Performing Test VERSION_SCRIPT_WORKS - Success
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)
Warning: doxygen not found, the 'doc' target will not be included
-- Configuring done
-- Generating done
-- Build files have been written to: C:/msys64/home/user/json-c/build

user@buildhost MINGW64 ~/json-c/build
$ cd ..

user@buildhost MINGW64 ~/json-c
$ cmake --build ./build --config Release
Scanning dependencies of target json-c
[  1%] Building C object CMakeFiles/json-c.dir/arraylist.c.obj
[  2%] Building C object CMakeFiles/json-c.dir/debug.c.obj
[  3%] Building C object CMakeFiles/json-c.dir/json_c_version.c.obj
[  4%] Building C object CMakeFiles/json-c.dir/json_object.c.obj
[  5%] Building C object CMakeFiles/json-c.dir/json_object_iterator.c.obj
[  7%] Building C object CMakeFiles/json-c.dir/json_pointer.c.obj
[  8%] Building C object CMakeFiles/json-c.dir/json_tokener.c.obj
[  9%] Building C object CMakeFiles/json-c.dir/json_util.c.obj
[ 10%] Building C object CMakeFiles/json-c.dir/json_visit.c.obj
[ 11%] Building C object CMakeFiles/json-c.dir/linkhash.c.obj
[ 13%] Building C object CMakeFiles/json-c.dir/printbuf.c.obj
[ 14%] Building C object CMakeFiles/json-c.dir/random_seed.c.obj
C:/msys64/home/user/json-c/random_seed.c: In function 'get_cryptgenrandom_seed':
C:/msys64/home/user/json-c/random_seed.c:274:6: error: unused variable 'r' [-Werror=unused-variable]
  274 |  int r;
      |      ^
cc1.exe: all warnings being treated as errors
make[2]: *** [CMakeFiles/json-c.dir/build.make:226: CMakeFiles/json-c.dir/random_seed.c.obj] Error 1
make[1]: *** [CMakeFiles/Makefile2:238: CMakeFiles/json-c.dir/all] Error 2
make: *** [Makefile:183: all] Error 2
```

Build Environment:
```bash
user@buildhost MINGW64 ~
$ uname -a
MINGW64_NT-10.0-19041 user@buildhost 3.1.7-340.x86_64 2020-11-08 12:32 UTC x86_64 Msys

user@buildhost MINGW64 ~
$ cmake --version
cmake version 3.17.3

CMake suite maintained and supported by Kitware (kitware.com/cmake).

user@buildhost MINGW64 ~
$ gcc --version
gcc.exe (Rev3, Built by MSYS2 project) 10.2.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```