### PR TITLE
[RFC] json_pointer: allow the feature to be disabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@
 # It's not good practice to build directly in the source tree
 # but ignore cmake auto-generated files anyway:
 /json_config.h
+/json.h
 /config.h
 /json-c.pc
 /Makefile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ option(ENABLE_RDRAND                  "Enable RDRAND Hardware RNG Hash Seed."   
 option(ENABLE_THREADING               "Enable partial threading support."                     OFF)
 option(OVERRIDE_GET_RANDOM_SEED       "Override json_c_get_random_seed() with custom code."   OFF)
 option(DISABLE_EXTRA_LIBS             "Avoid linking against extra libraries, such as libbsd." OFF)
+option(DISABLE_JSON_POINTER           "Disable JSON pointer (RFC6901) support."               OFF)
 
 
 if (UNIX OR MINGW OR CYGWIN)
@@ -370,14 +371,13 @@ set(JSON_C_PUBLIC_HEADERS
     # Note: config.h is _not_ included here
     ${PROJECT_BINARY_DIR}/json_config.h
 
-    ${PROJECT_SOURCE_DIR}/json.h
+    ${PROJECT_BINARY_DIR}/json.h
     ${PROJECT_SOURCE_DIR}/arraylist.h
     ${PROJECT_SOURCE_DIR}/debug.h
     ${PROJECT_SOURCE_DIR}/json_c_version.h
     ${PROJECT_SOURCE_DIR}/json_inttypes.h
     ${PROJECT_SOURCE_DIR}/json_object.h
     ${PROJECT_SOURCE_DIR}/json_object_iterator.h
-    ${PROJECT_SOURCE_DIR}/json_pointer.h
     ${PROJECT_SOURCE_DIR}/json_tokener.h
     ${PROJECT_SOURCE_DIR}/json_types.h
     ${PROJECT_SOURCE_DIR}/json_util.h
@@ -404,7 +404,6 @@ set(JSON_C_SOURCES
     ${PROJECT_SOURCE_DIR}/json_c_version.c
     ${PROJECT_SOURCE_DIR}/json_object.c
     ${PROJECT_SOURCE_DIR}/json_object_iterator.c
-    ${PROJECT_SOURCE_DIR}/json_pointer.c
     ${PROJECT_SOURCE_DIR}/json_tokener.c
     ${PROJECT_SOURCE_DIR}/json_util.c
     ${PROJECT_SOURCE_DIR}/json_visit.c
@@ -413,6 +412,16 @@ set(JSON_C_SOURCES
     ${PROJECT_SOURCE_DIR}/random_seed.c
     ${PROJECT_SOURCE_DIR}/strerror_override.c
 )
+
+if (NOT DISABLE_JSON_POINTER)
+    set(JSON_C_PUBLIC_HEADERS   ${JSON_C_PUBLIC_HEADERS}  ${PROJECT_SOURCE_DIR}/json_pointer.h)
+    set(JSON_C_SOURCES          ${JSON_C_SOURCES}         ${PROJECT_SOURCE_DIR}/json_pointer.c)
+    set(JSON_H_JSON_POINTER "#include \"json_pointer.h\"")
+else()
+    set(JSON_H_JSON_POINTER "")
+endif()
+
+configure_file(json.h.cmakein ${PROJECT_BINARY_DIR}/json.h @ONLY)
 
 include_directories(${PROJECT_SOURCE_DIR})
 include_directories(${PROJECT_BINARY_DIR})

--- a/json.h.cmakein
+++ b/json.h.cmakein
@@ -26,7 +26,7 @@ extern "C" {
 #include "json_c_version.h"
 #include "json_object.h"
 #include "json_object_iterator.h"
-#include "json_pointer.h"
+@JSON_H_JSON_POINTER@
 #include "json_tokener.h"
 #include "json_util.h"
 #include "linkhash.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,6 @@ set(ALL_TEST_NAMES
     test_double_serializer
     test_float
     test_int_add
-    test_json_pointer
     test_locale
     test_null
     test_parse
@@ -36,6 +35,10 @@ set(ALL_TEST_NAMES
     test_util_file
     test_visit
     test_object_iterator)
+
+if (NOT DISABLE_JSON_POINTER)
+    set(ALL_TEST_NAMES ${ALL_TEST_NAMES} test_json_pointer)
+endif()
 
 foreach(TESTNAME ${ALL_TEST_NAMES})
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,30 +12,32 @@ target_link_libraries(test2Formatted PRIVATE ${PROJECT_NAME})
 
 include_directories(PUBLIC ${CMAKE_SOURCE_DIR})
 
-foreach(TESTNAME
-	test1
-	test2
-	test4
-	testReplaceExisting
-	test_cast
-	test_charcase
-	test_compare
-	test_deep_copy
-	test_double_serializer
-	test_float
-	test_int_add
-	test_json_pointer
-	test_locale
-	test_null
-	test_parse
-	test_parse_int64
-	test_printbuf
-	test_set_serializer
-	test_set_value
-	test_strerror
-	test_util_file
-	test_visit
-	test_object_iterator)
+set(ALL_TEST_NAMES
+    test1
+    test2
+    test4
+    testReplaceExisting
+    test_cast
+    test_charcase
+    test_compare
+    test_deep_copy
+    test_double_serializer
+    test_float
+    test_int_add
+    test_json_pointer
+    test_locale
+    test_null
+    test_parse
+    test_parse_int64
+    test_printbuf
+    test_set_serializer
+    test_set_value
+    test_strerror
+    test_util_file
+    test_visit
+    test_object_iterator)
+
+foreach(TESTNAME ${ALL_TEST_NAMES})
 
 add_executable(${TESTNAME} ${TESTNAME}.c)
 if(${TESTNAME} STREQUAL test_strerror OR ${TESTNAME} STREQUAL test_util_file)


### PR DESCRIPTION
Some users may not want to included it in their build/system. So allow a
cmake symbol to disable it.

A user can do 'cmake -DDISABLE_JSON_POINTER=ON <json_c_root_dir>' and
disable the json_pointer functionality. That saves about 17 KB (on an
x86_64) machine. This may be useful on smaller embedded systems; even
though the saving would be fewer kilobytes.

One thing that also needs to change a bit, is that the 'json.h' be
autogenerated via cmake, in order to conditionally include that
"json_pointer.h" file.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>