### PR TITLE
Add AfterCaseLabel to .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,6 +23,8 @@ AllowShortFunctionsOnASingleLine:  Empty
 BreakBeforeBraces: Custom
 # Control of individual brace wrapping cases.
 BraceWrapping:
+  # Wrap brackets inside of a case
+  AfterCaseLabel: true
   # Wrap class definition.
   AfterClass: true
   # Wrap control statements


### PR DESCRIPTION
This is to fix the behavior that might've changed between older versions of clang-format, I'm not sure.
Regardless, version 10 (and possibly earlier, I didn't check) tries to put the bracket on the same line as case without this.