### PR TITLE
Allow null character in keys

### DIFF
--- a/json-c.sym
+++ b/json-c.sym
@@ -165,6 +165,9 @@ JSONC_0.15 {
 } JSONC_0.14;
 
 JSONC_0.16 {
-#  global:
-#      ...new symbols here...
+  global:
+    json_object_object_add_len;
+    json_object_object_add_ex_len;
+    json_object_object_get_len;
+    json_object_object_get_ex_len;
 } JSONC_0.15;

--- a/json-c.sym
+++ b/json-c.sym
@@ -3,7 +3,7 @@
  * Symbol versioning for libjson-c.
  * All exported symbols must be listed here.
  *
- * See 
+ * See
  *   https://software.intel.com/sites/default/files/m/a/1/e/dsohowto.pdf
  */
 
@@ -166,8 +166,12 @@ JSONC_0.15 {
 
 JSONC_0.16 {
   global:
+    lh_string_data;
+    lh_string_size;
+    lh_string_print;
     json_object_object_add_len;
     json_object_object_add_ex_len;
+    json_object_object_del_len;
     json_object_object_get_len;
     json_object_object_get_ex_len;
 } JSONC_0.15;

--- a/json_object.c
+++ b/json_object.c
@@ -116,8 +116,6 @@ static inline const struct json_object_string *JC_STRING_C(const struct json_obj
 static inline struct json_object *json_object_new(enum json_type o_type, size_t alloc_size,
                                                   json_object_to_json_string_fn *to_json_string);
 
-static int json_object_object_add_internal(struct json_object *jso, const struct lh_string *key,
-                                           struct json_object *const val, const unsigned opts);
 static int json_object_object_del_internal(struct json_object *jso_base,
                                            const struct lh_string *key);
 static json_bool json_object_object_get_internal(const struct json_object *jso,

--- a/json_object.c
+++ b/json_object.c
@@ -583,6 +583,12 @@ struct lh_table *json_object_get_object(const struct json_object *jso)
 int json_object_object_add_ex(struct json_object *jso, const char *const key,
                               struct json_object *const val, const unsigned opts)
 {
+	return json_object_object_add_ex_len(jso, key, strlen(key), val, opts);
+}
+
+int json_object_object_add_ex_len(struct json_object *jso, const char *const key, const int len,
+                                  struct json_object *const val, const unsigned opts)
+{
 	struct json_object *existing_value = NULL;
 	struct lh_entry *existing_entry;
 	unsigned long hash;
@@ -619,7 +625,13 @@ int json_object_object_add_ex(struct json_object *jso, const char *const key,
 
 int json_object_object_add(struct json_object *jso, const char *key, struct json_object *val)
 {
-	return json_object_object_add_ex(jso, key, val, 0);
+	return json_object_object_add_ex_len(jso, key, strlen(key), val, 0);
+}
+
+int json_object_object_add_len(struct json_object *jso, const char *key, const int len,
+                               struct json_object *val)
+{
+	return json_object_object_add_ex_len(jso, key, len, val, 0);
 }
 
 int json_object_object_length(const struct json_object *jso)
@@ -636,12 +648,26 @@ size_t json_c_object_sizeof(void)
 struct json_object *json_object_object_get(const struct json_object *jso, const char *key)
 {
 	struct json_object *result = NULL;
-	json_object_object_get_ex(jso, key, &result);
+	json_object_object_get_ex_len(jso, key, strlen(key), &result);
+	return result;
+}
+
+struct json_object *json_object_object_get_len(const struct json_object *jso, const char *key,
+                                               const int len)
+{
+	struct json_object *result = NULL;
+	json_object_object_get_ex_len(jso, key, len, &result);
 	return result;
 }
 
 json_bool json_object_object_get_ex(const struct json_object *jso, const char *key,
                                     struct json_object **value)
+{
+	return json_object_object_get_ex_len(jso, key, strlen(key), value);
+}
+
+json_bool json_object_object_get_ex_len(const struct json_object *jso, const char *key,
+                                        const int len, struct json_object **value)
 {
 	if (value != NULL)
 		*value = NULL;

--- a/json_object_iterator.c
+++ b/json_object_iterator.c
@@ -104,12 +104,12 @@ void json_object_iter_next(struct json_object_iterator *iter)
 /**
  * ****************************************************************************
  */
-const char *json_object_iter_peek_name(const struct json_object_iterator *iter)
+const struct lh_string *json_object_iter_peek_name(const struct json_object_iterator *iter)
 {
 	JASSERT(NULL != iter);
 	JASSERT(kObjectEndIterValue != iter->opaque_);
 
-	return (const char *)(((const struct lh_entry *)iter->opaque_)->k);
+	return (const struct lh_string *)(((const struct lh_entry *)iter->opaque_)->k);
 }
 
 /**

--- a/json_object_iterator.h
+++ b/json_object_iterator.h
@@ -168,7 +168,8 @@ JSON_EXPORT void json_object_iter_next(struct json_object_iterator *iter);
  *         deleted or modified, and MUST NOT be modified or
  *         freed by the user.
  */
-JSON_EXPORT const char *json_object_iter_peek_name(const struct json_object_iterator *iter);
+JSON_EXPORT const struct lh_string *
+json_object_iter_peek_name(const struct json_object_iterator *iter);
 
 /** Returns a pointer to the json-c instance representing the
  *  value of the referenced name/value pair, without altering

--- a/json_object_private.h
+++ b/json_object_private.h
@@ -98,6 +98,9 @@ struct json_object_string
 
 void _json_c_set_last_err(const char *err_fmt, ...);
 
+/**
+ * The characters that can make up hexadecimal numbers
+ */
 extern const char *json_hex_chars;
 
 #ifdef __cplusplus

--- a/json_object_private.h
+++ b/json_object_private.h
@@ -99,6 +99,22 @@ struct json_object_string
 void _json_c_set_last_err(const char *err_fmt, ...);
 
 /**
+ * @brief Add an object field to a json_object of type json_type_object
+ *
+ * The semantics are identical to json_object_object_add_ex, except that @p key
+ * contains both the data and the length.
+ *
+ * @param obj the json_object instance
+ * @param key the object field name (a private copy will be duplicated)
+ * @param val a json_object or NULL member to associate with the given field
+ * @param opts process-modifying options. To specify multiple options, use
+ *             (OPT1|OPT2)
+ * @return On success, @c 0 is returned.
+ *         On error, a negative value is returned.
+ */
+int json_object_object_add_internal(struct json_object *obj, const struct lh_string *key,
+                                    struct json_object *const val, const unsigned opts);
+/**
  * The characters that can make up hexadecimal numbers
  */
 extern const char *json_hex_chars;

--- a/json_tokener.c
+++ b/json_tokener.c
@@ -1105,7 +1105,9 @@ struct json_object *json_tokener_parse_ex(struct json_tokener *tok, const char *
 				{
 					printbuf_memappend_fast(tok->pb, case_start,
 					                        str - case_start);
-					obj_field_name = strdup(tok->pb->buf);
+					obj_field_name =
+					    lh_string_new_imm(tok->pb->bpos, tok->pb->buf);
+					// lh_string_print(obj_field_name, stdout);
 					saved_state = json_tokener_state_object_field_end;
 					state = json_tokener_state_eatws;
 					break;
@@ -1153,7 +1155,7 @@ struct json_object *json_tokener_parse_ex(struct json_tokener *tok, const char *
 			goto redo_char;
 
 		case json_tokener_state_object_value_add:
-			json_object_object_add(current, obj_field_name, obj);
+			json_object_object_add_internal(current, obj_field_name, obj, 0);
 			free(obj_field_name);
 			obj_field_name = NULL;
 			saved_state = json_tokener_state_object_sep;

--- a/json_tokener.h
+++ b/json_tokener.h
@@ -17,6 +17,7 @@
 #define _json_tokener_h_
 
 #include "json_object.h"
+#include "linkhash.h"
 #include <stddef.h>
 
 #ifdef __cplusplus
@@ -85,7 +86,7 @@ struct json_tokener_srec
 	enum json_tokener_state state, saved_state;
 	struct json_object *obj;
 	struct json_object *current;
-	char *obj_field_name;
+	struct lh_string *obj_field_name;
 };
 
 #define JSON_TOKENER_DEFAULT_DEPTH 32
@@ -215,7 +216,7 @@ JSON_EXPORT struct json_tokener *json_tokener_new_ex(int depth);
 JSON_EXPORT void json_tokener_free(struct json_tokener *tok);
 
 /**
- * Reset the state of a json_tokener, to prepare to parse a 
+ * Reset the state of a json_tokener, to prepare to parse a
  * brand new JSON object.
  */
 JSON_EXPORT void json_tokener_reset(struct json_tokener *tok);
@@ -279,7 +280,7 @@ JSON_EXPORT void json_tokener_set_flags(struct json_tokener *tok, int flags);
  * the length of the last len parameter passed in.
  *
  * The tokener does \b not maintain an internal buffer so the caller is
- * responsible for a subsequent call to json_tokener_parse_ex with an 
+ * responsible for a subsequent call to json_tokener_parse_ex with an
  * appropriate str parameter starting with the extra characters.
  *
  * This interface is presently not 64-bit clean due to the int len argument

--- a/json_types.h
+++ b/json_types.h
@@ -33,7 +33,7 @@ struct printbuf;
  */
 struct json_object_iter
 {
-	char *key;
+	struct lh_string *key;
 	struct json_object *val;
 	struct lh_entry *entry;
 };

--- a/json_visit.c
+++ b/json_visit.c
@@ -13,7 +13,7 @@
 #include "json_visit.h"
 #include "linkhash.h"
 
-static int _json_c_visit(json_object *jso, json_object *parent_jso, const char *jso_key,
+static int _json_c_visit(json_object *jso, json_object *parent_jso, const struct lh_string *jso_key,
                          size_t *jso_index, json_c_visit_userfunc *userfunc, void *userarg);
 
 int json_c_visit(json_object *jso, int future_flags, json_c_visit_userfunc *userfunc, void *userarg)
@@ -28,7 +28,7 @@ int json_c_visit(json_object *jso, int future_flags, json_c_visit_userfunc *user
 	default: return JSON_C_VISIT_RETURN_ERROR;
 	}
 }
-static int _json_c_visit(json_object *jso, json_object *parent_jso, const char *jso_key,
+static int _json_c_visit(json_object *jso, json_object *parent_jso, const struct lh_string *jso_key,
                          size_t *jso_index, json_c_visit_userfunc *userfunc, void *userarg)
 {
 	int userret = userfunc(jso, 0, parent_jso, jso_key, jso_index, userarg);

--- a/json_visit.h
+++ b/json_visit.h
@@ -13,7 +13,8 @@ extern "C" {
 #endif
 
 typedef int(json_c_visit_userfunc)(json_object *jso, int flags, json_object *parent_jso,
-                                   const char *jso_key, size_t *jso_index, void *userarg);
+                                   const struct lh_string *jso_key, size_t *jso_index,
+                                   void *userarg);
 
 /**
  * Visit each object in the JSON hierarchy starting at jso.

--- a/linkhash.c
+++ b/linkhash.c
@@ -506,6 +506,11 @@ size_t lh_string_size(const struct lh_string *str)
 	return (str->length > 0) ? (size_t)str->length : (size_t)(-(str->length));
 }
 
+size_t lh_string_print(const struct lh_string *key, FILE *stream)
+{
+	return fwrite(lh_string_data(key), lh_string_size(key), 1, stream);
+}
+
 const struct lh_string *lh_string_new_ptr(const size_t length, const char *data)
 {
 	struct lh_string *result = malloc(sizeof(struct lh_string));
@@ -535,7 +540,7 @@ const struct lh_string *lh_string_new_imm(const size_t length, const char *data)
 	result->length = -length;
 	char *unconst = _LH_UNCONST(result->str.idata);
 	memcpy(unconst, data, length);
-	unconst = '\0';
+	unconst[length] = '\0';
 	return result;
 }
 

--- a/linkhash.c
+++ b/linkhash.c
@@ -30,6 +30,7 @@
 #endif
 
 #include "linkhash.h"
+#include "math_compat.h"
 #include "random_seed.h"
 
 /* hash functions */
@@ -485,13 +486,57 @@ static unsigned long lh_char_hash(const void *k)
 		random_seed = seed; /* potentially racy */
 #endif
 	}
-
-	return hashlittle((const char *)k, strlen((const char *)k), random_seed);
+	return hashlittle(lh_string_data((const struct lh_string *)k),
+	                  lh_string_size((const struct lh_string *)k), random_seed);
 }
 
 int lh_char_equal(const void *k1, const void *k2)
 {
-	return (strcmp((const char *)k1, (const char *)k2) == 0);
+	return lh_string_size(k1) == lh_string_size(k2) &&
+	       memcmp(lh_string_data(k1), lh_string_data(k2), lh_string_size(k1)) == 0;
+}
+
+const char *lh_string_data(const struct lh_string *str)
+{
+	return (str->length > 0) ? str->str.pdata : str->str.idata;
+}
+
+size_t lh_string_size(const struct lh_string *str)
+{
+	return (str->length > 0) ? (size_t)str->length : (size_t)(-(str->length));
+}
+
+const struct lh_string *lh_string_new_ptr(const size_t length, const char *data)
+{
+	struct lh_string *result = malloc(sizeof(struct lh_string));
+	if (result == NULL)
+	{
+		return NULL;
+	}
+	result->length = length;
+	result->str.pdata = data;
+	return result;
+}
+
+const struct lh_string *lh_string_new_imm(const size_t length, const char *data)
+{
+	struct lh_string *result;
+	if (length >
+	    SSIZE_T_MAX - (sizeof(struct lh_string) - sizeof(((struct lh_string *)NULL)->str)) - 1)
+	{
+		return NULL;
+	}
+	result =
+	    malloc(sizeof(struct lh_string) - sizeof(((struct lh_string *)NULL)->str) + length + 1);
+	if (result == NULL)
+	{
+		return NULL;
+	}
+	result->length = -length;
+	char *unconst = _LH_UNCONST(result->str.idata);
+	memcpy(unconst, data, length);
+	unconst = '\0';
+	return result;
 }
 
 struct lh_table *lh_table_new(int size, lh_entry_free_fn *free_fn, lh_hash_fn *hash_fn,

--- a/linkhash.c
+++ b/linkhash.c
@@ -511,7 +511,7 @@ size_t lh_string_print(const struct lh_string *key, FILE *stream)
 	return fwrite(lh_string_data(key), lh_string_size(key), 1, stream);
 }
 
-const struct lh_string *lh_string_new_ptr(const size_t length, const char *data)
+struct lh_string *lh_string_new_ptr(const size_t length, const char *data)
 {
 	struct lh_string *result = malloc(sizeof(struct lh_string));
 	if (result == NULL)
@@ -523,7 +523,7 @@ const struct lh_string *lh_string_new_ptr(const size_t length, const char *data)
 	return result;
 }
 
-const struct lh_string *lh_string_new_imm(const size_t length, const char *data)
+struct lh_string *lh_string_new_imm(const size_t length, const char *data)
 {
 	struct lh_string *result;
 	if (length >

--- a/linkhash.h
+++ b/linkhash.h
@@ -20,6 +20,7 @@
 #define _json_c_linkhash_h_
 
 #include "json_object.h"
+#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -205,6 +206,14 @@ extern const char *lh_string_data(const struct lh_string *str);
  * @param str value to retrieve the length of
  */
 extern size_t lh_string_size(const struct lh_string *str);
+
+/**
+ * @brief Print a `struct lh_string` to a given stream
+ *
+ * @param str value to print
+ * @param stream Stream to write data to
+ */
+extern size_t lh_string_print(const struct lh_string *str, FILE *stream);
 
 /**
  * @brief Creates a new `struct lh_string` using the `pdata` field.

--- a/linkhash.h
+++ b/linkhash.h
@@ -225,7 +225,7 @@ extern size_t lh_string_print(const struct lh_string *str, FILE *stream);
  * @param data The data to include
  * @return `NULL` on error
  */
-extern const struct lh_string *lh_string_new_ptr(const size_t length, const char *data);
+extern struct lh_string *lh_string_new_ptr(const size_t length, const char *data);
 
 /**
  * @brief Creates a new `struct lh_string` using the `idata` field.
@@ -234,7 +234,7 @@ extern const struct lh_string *lh_string_new_ptr(const size_t length, const char
  * @param data The data to include and copy into the returned value
  * @return `NULL` on error
  */
-extern const struct lh_string *lh_string_new_imm(const size_t length, const char *data);
+extern struct lh_string *lh_string_new_imm(const size_t length, const char *data);
 
 /**
  * Create a new linkhash table.

--- a/math_compat.h
+++ b/math_compat.h
@@ -40,4 +40,17 @@
 #define HAVE_DECL_NAN
 #endif
 
+#include <limits.h>
+#ifndef SSIZE_T_MAX
+#if SIZEOF_SSIZE_T == SIZEOF_INT
+#define SSIZE_T_MAX INT_MAX
+#elif SIZEOF_SSIZE_T == SIZEOF_LONG
+#define SSIZE_T_MAX LONG_MAX
+#elif SIZEOF_SSIZE_T == SIZEOF_LONG_LONG
+#define SSIZE_T_MAX LLONG_MAX
+#else
+#error Unable to determine size of ssize_t
+#endif
+#endif
+
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,8 @@ set(ALL_TEST_NAMES
     test_int_add
     test_locale
     test_null
+    test_null_keys_add
+    test_null_keys_get
     test_parse
     test_parse_int64
     test_printbuf

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,8 @@ set(ALL_TEST_NAMES
     test_null
     test_null_keys_add
     test_null_keys_get
+    test_null_keys_del
+    test_null_keys_print
     test_parse
     test_parse_int64
     test_printbuf

--- a/tests/test1.c
+++ b/tests/test1.c
@@ -306,7 +306,9 @@ int main(int argc, char **argv)
 	printf("my_object=\n");
 	json_object_object_foreach(my_object, key, val)
 	{
-		printf("\t%s: %s\n", key, json_object_to_json_string(val));
+		putchar('\t');
+		lh_string_print(key, stdout);
+		printf(": %s\n", json_object_to_json_string(val));
 	}
 	printf("my_object.to_string()=%s\n", json_object_to_json_string(my_object));
 

--- a/tests/testReplaceExisting.c
+++ b/tests/testReplaceExisting.c
@@ -24,10 +24,11 @@ int main(int argc, char **argv)
 	int orig_count = 0;
 	json_object_object_foreach(my_object, key0, val0)
 	{
-		printf("Key at index %d is [%s] %d", orig_count, key0, (val0 == NULL));
-		if (strcmp(key0, "deleteme") == 0)
+		printf("Key at index %d is [%s] %d", orig_count, lh_string_data(key0),
+		       (val0 == NULL));
+		if (strcmp(lh_string_data(key0), "deleteme") == 0)
 		{
-			json_object_object_del(my_object, key0);
+			json_object_object_del(my_object, lh_string_data(key0));
 			printf(" (deleted)\n");
 		}
 		else
@@ -37,17 +38,19 @@ int main(int argc, char **argv)
 
 	printf("==== replace-value first loop starting ====\n");
 
-	const char *original_key = NULL;
+	const struct lh_string *original_key = NULL;
 	orig_count = 0;
 	json_object_object_foreach(my_object, key, val)
 	{
-		printf("Key at index %d is [%s] %d\n", orig_count, key, (val == NULL));
+		printf("Key at index %d is [%s] %d\n", orig_count, lh_string_data(key),
+		       (val == NULL));
 		orig_count++;
-		if (strcmp(key, "foo2") != 0)
+		if (strcmp(lh_string_data(key), "foo2") != 0)
 			continue;
-		printf("replacing value for key [%s]\n", key);
+		printf("replacing value for key [%s]\n", lh_string_data(key));
 		original_key = key;
-		json_object_object_add(my_object, key, json_object_new_string("zzz"));
+		json_object_object_add(my_object, lh_string_data(key0),
+		                       json_object_new_string("zzz"));
 	}
 
 	printf("==== second loop starting ====\n");
@@ -56,11 +59,12 @@ int main(int argc, char **argv)
 	int retval = 0;
 	json_object_object_foreach(my_object, key2, val2)
 	{
-		printf("Key at index %d is [%s] %d\n", new_count, key2, (val2 == NULL));
+		printf("Key at index %d is [%s] %d\n", new_count, lh_string_data(key2),
+		       (val2 == NULL));
 		new_count++;
-		if (strcmp(key2, "foo2") != 0)
+		if (strcmp(lh_string_data(key2), "foo2") != 0)
 			continue;
-		printf("pointer for key [%s] does %smatch\n", key2,
+		printf("pointer for key [%s] does %smatch\n", lh_string_data(key2),
 		       (key2 == original_key) ? "" : "NOT ");
 		if (key2 != original_key)
 			retval = 1;

--- a/tests/test_deep_copy.c
+++ b/tests/test_deep_copy.c
@@ -93,14 +93,14 @@ int my_custom_serializer(struct json_object *jso, struct printbuf *pb, int level
 }
 
 json_c_shallow_copy_fn my_shallow_copy;
-int my_shallow_copy(json_object *src, json_object *parent, const char *key, size_t index,
-                    json_object **dst)
+int my_shallow_copy(json_object *src, json_object *parent, const struct lh_string *key,
+                    size_t index, json_object **dst)
 {
 	int rc;
 	rc = json_c_shallow_copy_default(src, parent, key, index, dst);
 	if (rc < 0)
 		return rc;
-	if (key != NULL && strcmp(key, "with_serializer") == 0)
+	if (key != NULL && strcmp(lh_string_data(key), "with_serializer") == 0)
 	{
 		printf("CALLED: my_shallow_copy on with_serializer object\n");
 		void *userdata = json_object_get_userdata(src);

--- a/tests/test_null_keys_add.c
+++ b/tests/test_null_keys_add.c
@@ -1,0 +1,123 @@
+/*
+ * Tests if binary strings are supported.
+ */
+
+#include "config.h"
+#include <stdio.h>
+#include <string.h>
+
+#include "json_inttypes.h"
+#include "json_object.h"
+#include "json_tokener.h"
+
+int main(void)
+{
+	/* this test has embedded null characters in the key and value.
+	 * check that it's still included after deserializing. */
+	const char *input = "{ \"foo\": 14.5, \"bar\": [] }";
+	const char *foo_key = "foo";
+	const char *foo_value = "14.5";
+	const char *bar_key = "bar";
+
+	const char *toadd_key = "foo\0bar";
+	const int toadd_key_len = 7;
+	const char *toadd_key_printable = "foo\\0bar";
+	const char *toadd_value = "qwerty\0asdf";
+	const int toadd_value_len = 12;
+	const char *toadd_value_printable = "qwerty\\0asdf";
+
+	struct json_object *parsed = json_tokener_parse(input);
+
+	printf("Parsed input: %s\n", input);
+	printf("Result is ");
+	if (parsed == NULL)
+	{
+		printf("NULL (error!)\n");
+		return 1; // Error somewhere
+	}
+	else if (!json_object_is_type(parsed, json_type_object))
+	{
+		printf("not `json_type_object` (error!)\n");
+		return 1; // Error somewhere
+	}
+	else
+	{
+		printf("`json_type_object`\n");
+	}
+
+	// Check nothing odd happened in parsing
+	if (json_object_object_length(parsed) != 2)
+	{
+		printf("Should contain two fields (has %d) (error!)",
+		       json_object_object_length(parsed));
+		return 1;
+	}
+	json_bool key_present = json_object_object_get_ex(parsed, foo_key, NULL);
+	if (!key_present)
+	{
+		printf("Should contain key \"%s\", but does not (error!)", foo_key);
+		return 1;
+	}
+	key_present = json_object_object_get_ex(parsed, bar_key, NULL);
+	if (!key_present)
+	{
+		printf("Should contain key \"%s\", but does not (error!)", bar_key);
+		return 1;
+	}
+
+	// Add the new key
+	struct json_object *new_str = json_object_new_string_len(toadd_value, toadd_value_len);
+	if (json_object_object_add_ex(parsed, toadd_key, new_str,
+	                              JSON_C_OBJECT_ADD_KEY_IS_NEW |
+	                                  JSON_C_OBJECT_KEY_IS_CONSTANT) != 0)
+	{
+		printf("An error occured adding the key \"%s\" (error!)\n", toadd_key_printable);
+		return 1;
+	}
+
+	// Check the new key was actually added
+	if (json_object_object_length(parsed) != 3)
+	{
+		printf("Should contain three fields after adding new key (has %d) (error!)",
+		       json_object_object_length(parsed));
+		return 1;
+	}
+	else if (json_object_object_get_len(parsed, toadd_key, toadd_key_len) != new_str)
+	{
+		printf("Have three keys, but don't have the right value in \"%s\" (error!)\n",
+		       toadd_key_printable);
+		return 1;
+	}
+	else
+	{
+		printf("Added the key \"%s\" successfully\n", toadd_key_printable);
+	}
+
+	// Check the previous keys are still the same present
+	struct json_object *foo = json_object_object_get(parsed, foo_key);
+	if (!json_object_is_type(foo, json_type_double))
+	{
+		printf("Key \"%s\" should be `json_type_double` (%d) but was %d (error!)\n",
+		       foo_key, (int)json_type_double, json_object_get_type(foo));
+		return 1;
+	}
+	else
+	{
+		printf("Key \"%s\" is still the same\n", foo_key);
+	}
+	struct json_object *bar = json_object_object_get(parsed, bar_key);
+	if (!json_object_is_type(foo, json_type_array))
+	{
+		printf("Key \"%s\" should be `json_type_array` (%d) but was %d (error!)\n", bar_key,
+		       (int)json_type_array, json_object_get_type(foo));
+		return 1;
+	}
+	else
+	{
+		printf("Key \"%s\" is still the same\n", bar_key);
+	}
+
+	json_object_put(parsed);
+	printf("PASS\n");
+	return 0;
+}

--- a/tests/test_null_keys_add.c
+++ b/tests/test_null_keys_add.c
@@ -9,6 +9,7 @@
 #include "json_inttypes.h"
 #include "json_object.h"
 #include "json_tokener.h"
+#include "linkhash.h"
 
 int main(void)
 {
@@ -65,10 +66,33 @@ int main(void)
 		return 1;
 	}
 
+	// Check the previous keys are still the same present
+	struct json_object *foo = json_object_object_get(parsed, foo_key);
+	if (!json_object_is_type(foo, json_type_double))
+	{
+		printf("Key \"%s\" should be `json_type_double` (%d) but was %d (error!)\n",
+		       foo_key, (int)json_type_double, json_object_get_type(foo));
+		return 1;
+	}
+	else
+	{
+		printf("Key \"%s\" parsed as right type\n", foo_key);
+	}
+	struct json_object *bar = json_object_object_get(parsed, bar_key);
+	if (!json_object_is_type(bar, json_type_array))
+	{
+		printf("Key \"%s\" should be `json_type_array` (%d) but was %d (error!)\n", bar_key,
+		       (int)json_type_array, json_object_get_type(bar));
+		return 1;
+	}
+	else
+	{
+		printf("Key \"%s\" parsed as right type\n", bar_key);
+	}
+
 	// Add the new key
 	struct json_object *new_str = json_object_new_string_len(toadd_value, toadd_value_len);
-	if (json_object_object_add_ex(parsed, toadd_key, new_str,
-	                              JSON_C_OBJECT_ADD_KEY_IS_NEW |
+	if (json_object_object_add_ex_len(parsed, toadd_key, toadd_key_len, new_str,
 	                                  JSON_C_OBJECT_KEY_IS_CONSTANT) != 0)
 	{
 		printf("An error occured adding the key \"%s\" (error!)\n", toadd_key_printable);
@@ -86,6 +110,13 @@ int main(void)
 	{
 		printf("Have three keys, but don't have the right value in \"%s\" (error!)\n",
 		       toadd_key_printable);
+		printf("Keys :\n");
+		json_object_object_foreach(parsed, key, val)
+		{
+			putchar('\"');
+			fwrite(lh_string_data(key), lh_string_size(key), 1, stdout);
+			printf("\" (%zd)\n", lh_string_size(key));
+		}
 		return 1;
 	}
 	else
@@ -94,7 +125,7 @@ int main(void)
 	}
 
 	// Check the previous keys are still the same present
-	struct json_object *foo = json_object_object_get(parsed, foo_key);
+	foo = json_object_object_get(parsed, foo_key);
 	if (!json_object_is_type(foo, json_type_double))
 	{
 		printf("Key \"%s\" should be `json_type_double` (%d) but was %d (error!)\n",
@@ -105,11 +136,11 @@ int main(void)
 	{
 		printf("Key \"%s\" is still the same\n", foo_key);
 	}
-	struct json_object *bar = json_object_object_get(parsed, bar_key);
-	if (!json_object_is_type(foo, json_type_array))
+	bar = json_object_object_get(parsed, bar_key);
+	if (!json_object_is_type(bar, json_type_array))
 	{
 		printf("Key \"%s\" should be `json_type_array` (%d) but was %d (error!)\n", bar_key,
-		       (int)json_type_array, json_object_get_type(foo));
+		       (int)json_type_array, json_object_get_type(bar));
 		return 1;
 	}
 	else

--- a/tests/test_null_keys_add.expected
+++ b/tests/test_null_keys_add.expected
@@ -1,5 +1,7 @@
 Parsed input: { "foo": 14.5, "bar": [] }
 Result is `json_type_object`
+Key "foo" parsed as right type
+Key "bar" parsed as right type
 Added the key "foo\0bar" successfully
 Key "foo" is still the same
 Key "bar" is still the same

--- a/tests/test_null_keys_add.expected
+++ b/tests/test_null_keys_add.expected
@@ -1,0 +1,6 @@
+Parsed input: { "foo": 14.5, "bar": [] }
+Result is `json_type_object`
+Added the key "foo\0bar" successfully
+Key "foo" is still the same
+Key "bar" is still the same
+PASS

--- a/tests/test_null_keys_add.test
+++ b/tests/test_null_keys_add.test
@@ -1,0 +1,1 @@
+test_basic.test

--- a/tests/test_null_keys_del.c
+++ b/tests/test_null_keys_del.c
@@ -1,0 +1,100 @@
+/*
+ * Tests if binary strings are supported.
+ */
+
+#include "config.h"
+#include <stdio.h>
+#include <string.h>
+
+#include "json_inttypes.h"
+#include "json_object.h"
+#include "json_tokener.h"
+
+int main(void)
+{
+	/* this test has embedded null characters in the key and value.
+	 * check that it's still included after deserializing. */
+	const char *input = "{ \"biff\\u0000\": null, \"\\u0000zxcvbnm\": 178 }";
+	const char *expected_biff = "biff\0";
+	const int expected_biff_len = 5;
+	const char *expected_biff_printable = "biff\\u0000";
+	const char *expected_zxcv = "\0zxcvbnm";
+	const int expected_zxcv_len = 8;
+	const char *expected_zxcv_printable = "\\u0000zxcvbnm";
+
+	struct json_object *parsed = json_tokener_parse(input);
+	struct json_object *val;
+	json_bool key_present;
+
+	printf("Parsed input: %s\n", input);
+	printf("Result is ");
+	if (parsed == NULL)
+	{
+		printf("NULL (error!)\n");
+		return 1; // Error somewhere
+	}
+	else if (!json_object_is_type(parsed, json_type_object))
+	{
+		printf("not `json_type_object` (error!)\n");
+		return 1; // Error somewhere
+	}
+	else
+	{
+		printf("`json_type_object`\n");
+	}
+
+	// Check nothing odd happened in parsing
+	if (json_object_object_length(parsed) != 2)
+	{
+		printf("Should contain two fields (has %d) (error!)",
+		       json_object_object_length(parsed));
+		return 1;
+	}
+
+	key_present = json_object_object_get_ex_len(parsed, expected_biff, expected_biff_len, &val);
+	if (!key_present || !json_object_is_type(val, json_type_null))
+	{
+		printf("The key \"%s\" should be present and should be NULL (error!)\n",
+		       expected_biff_printable);
+		return 1;
+	}
+	key_present = json_object_object_get_ex_len(parsed, expected_zxcv, expected_zxcv_len, &val);
+	if (!key_present || !json_object_is_type(val, json_type_int) ||
+	    json_object_get_int(val) != 178)
+	{
+		printf("The key \"%s\" should be present and should be 178 (error!)\n",
+		       expected_zxcv_printable);
+		return 1;
+	}
+	printf("Expected keys (\"%s\" and \"%s\") present with expected values\n",
+	       expected_biff_printable, expected_zxcv_printable);
+
+	// Delete one key
+	json_object_object_del_len(parsed, expected_zxcv, expected_zxcv_len);
+
+	// Check it is gone
+	if (json_object_object_length(parsed) != 1)
+	{
+		printf("Should contain only one field (has %d) (error!)",
+		       json_object_object_length(parsed));
+		return 1;
+	}
+	key_present = json_object_object_get_ex_len(parsed, expected_biff, expected_biff_len, &val);
+	if (!key_present || !json_object_is_type(val, json_type_null))
+	{
+		printf("The key \"%s\" should be present and should be NULL (error!)\n",
+		       expected_biff_printable);
+		return 1;
+	}
+	key_present = json_object_object_get_ex_len(parsed, expected_zxcv, expected_zxcv_len, &val);
+	if (key_present)
+	{
+		printf("The key \"%s\" should not be present (error!)\n", expected_zxcv_printable);
+		return 1;
+	}
+	printf("Key deleted properly\n");
+
+	json_object_put(parsed);
+	printf("PASS\n");
+	return 0;
+}

--- a/tests/test_null_keys_del.expected
+++ b/tests/test_null_keys_del.expected
@@ -1,0 +1,5 @@
+Parsed input: { "biff\u0000": null, "\u0000zxcvbnm": 178 }
+Result is `json_type_object`
+Expected keys ("biff\0" and "\0zxcvbnm") present with expected values
+Key deleted properly
+PASS

--- a/tests/test_null_keys_del.test
+++ b/tests/test_null_keys_del.test
@@ -1,0 +1,1 @@
+test_basic.test

--- a/tests/test_null_keys_get.c
+++ b/tests/test_null_keys_get.c
@@ -1,0 +1,139 @@
+/*
+ * Tests if binary strings are supported.
+ */
+
+#include "config.h"
+#include <stdio.h>
+#include <string.h>
+
+#include "json_inttypes.h"
+#include "json_object.h"
+#include "json_tokener.h"
+
+int main(void)
+{
+	/* this test has embedded null characters in the key and value.
+	 * check that it's still included after deserializing. */
+	const char *input = "{ \"foo\\u0000bar\": \"qwerty\\u0000asdf\" }";
+	const char *expected_key = "foo\0bar";
+	const int expected_key_len = 7;
+	const char *expected_key_printable = "foo\\0bar";
+	const char *expected_value = "qwerty\0asdf";
+	const int expected_value_len = 12;
+	const char *expected_value_printable = "qwerty\\0asdf";
+
+	struct json_object *parsed = json_tokener_parse(input);
+
+	printf("Parsed input: %s\n", input);
+	printf("Result is ");
+	if (parsed == NULL)
+	{
+		printf("NULL (error!)\n");
+		return 1; // Error somewhere
+	}
+	else if (!json_object_is_type(parsed, json_type_object))
+	{
+		printf("not `json_type_object` (error!)\n");
+		return 1; // Error somewhere
+	}
+	else
+	{
+		printf("`json_type_object`\n");
+	}
+
+	// Check nothing odd happened in parsing
+	if (json_object_object_length(parsed) != 1)
+	{
+		printf("Should contain only one field (has %d) (error!)",
+		       json_object_object_length(parsed));
+		return 1;
+	}
+	json_bool key_present = json_object_object_get_ex(parsed, expected_key, NULL);
+	if (key_present)
+	{
+		printf("The key \"%s\" should not be present when calling "
+		       "`json_object_object_get_ex` "
+		       "(the real key contains a NUL character). (error!)\n",
+		       expected_key);
+		return 1;
+	}
+
+	// Check the key is present
+	struct json_object *string;
+	key_present = json_object_object_get_ex_len(parsed, expected_key, 7, &string);
+	if (!key_present)
+	{
+		printf("The key \"%s\" should be present when calling "
+		       "`json_object_object_get_ex_len` (error!)\n",
+		       expected_key_printable);
+		return 1;
+	}
+	else if (string == NULL)
+	{
+		printf("The key \"%s\" was present when calling "
+		       "`json_object_object_get_ex_len`, but got NULL (error!)\n",
+		       expected_key_printable);
+		return 1;
+	}
+	struct json_object *from_get_len = json_object_object_get_len(parsed, expected_key, 7);
+	if (string != from_get_len)
+	{
+		printf("The value returned from `json_object_object_get_len` should be the "
+		       "same as the one from `json_object_object_get_ex_len` (error!)\n"
+		       "Got %p from `json_object_object_get_ex_len` but %p from "
+		       "`json_object_object_get_len`\n",
+		       string, from_get_len);
+		return 1;
+	}
+	else
+	{
+		printf("Key was present and same for "
+		       "`json_object_object_get_ex_len` and `json_object_object_get_len`\n");
+	}
+
+	// Check the value is right
+	if (!json_object_is_type(string, json_type_string))
+	{
+		printf(
+		    "Value is wrong type, expected `json_type_string` (%d) but got %d (error!)\n",
+		    json_type_string, json_object_get_type(string));
+		return 1;
+	}
+	else
+	{
+		printf("Value is right type, `json_type_string`\n");
+	}
+	const int actual_value_len = json_object_get_string_len(string);
+	const char *actual_value = json_object_get_string(string);
+	if (actual_value_len != expected_value_len)
+	{
+		printf("Value is wrong length, expected %d but got %d (error!)\n",
+		       expected_value_len, actual_value_len);
+		return 1;
+	}
+	else if (memcmp(expected_value, actual_value, actual_value_len) != 0)
+	{
+		printf("Expected \"%s\" but got \"", expected_value_printable);
+		for (int i = 0; i < actual_value_len; ++i)
+		{
+			if (actual_value[i] == '\0')
+			{
+				puts("\\0");
+			}
+			else
+			{
+				putchar(actual_value[i]);
+			}
+		}
+		printf("\"\n");
+		return 1;
+	}
+	else
+	{
+		printf("Expected value matches actual\n");
+	}
+
+	json_object_put(parsed);
+	printf("PASS\n");
+	return 0;
+}

--- a/tests/test_null_keys_get.c
+++ b/tests/test_null_keys_get.c
@@ -19,7 +19,7 @@ int main(void)
 	const int expected_key_len = 7;
 	const char *expected_key_printable = "foo\\0bar";
 	const char *expected_value = "qwerty\0asdf";
-	const int expected_value_len = 12;
+	const int expected_value_len = 11;
 	const char *expected_value_printable = "qwerty\\0asdf";
 
 	struct json_object *parsed = json_tokener_parse(input);

--- a/tests/test_null_keys_get.expected
+++ b/tests/test_null_keys_get.expected
@@ -1,0 +1,6 @@
+Parsed input: { "foo\u0000bar": "qwerty\u0000asdf" }
+Result is `json_type_object`
+Key was present and same for `json_object_object_get_ex_len` and `json_object_object_get_len`
+Value is right type, `json_type_string`
+Expected value matches actual
+PASS

--- a/tests/test_null_keys_get.test
+++ b/tests/test_null_keys_get.test
@@ -1,0 +1,1 @@
+test_basic.test

--- a/tests/test_null_keys_print.c
+++ b/tests/test_null_keys_print.c
@@ -1,0 +1,18 @@
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "json.h"
+#include "parse_flags.h"
+
+int main(int argc, char **argv)
+{
+	struct json_object *new_obj;
+
+	new_obj = json_tokener_parse("{ \"foo\\u0000bar\": \"qwerty\\u0000asdf\" }");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
+
+	return EXIT_SUCCESS;
+}

--- a/tests/test_null_keys_print.expected
+++ b/tests/test_null_keys_print.expected
@@ -1,0 +1,1 @@
+new_obj.to_string()={ "foo\u0000bar": "qwerty\u0000asdf" }

--- a/tests/test_null_keys_print.test
+++ b/tests/test_null_keys_print.test
@@ -1,0 +1,1 @@
+test_basic.test

--- a/tests/test_object_iterator.c
+++ b/tests/test_object_iterator.c
@@ -6,6 +6,7 @@
 #include "json_object.h"
 #include "json_object_iterator.h"
 #include "json_tokener.h"
+#include "linkhash.h"
 
 int main(int atgc, char **argv)
 {
@@ -30,7 +31,7 @@ int main(int atgc, char **argv)
 
 	while (!json_object_iter_equal(&it, &itEnd))
 	{
-		printf("%s\n", json_object_iter_peek_name(&it));
+		printf("%s\n", lh_string_data(json_object_iter_peek_name(&it)));
 		printf("%s\n", json_object_to_json_string(json_object_iter_peek_value(&it)));
 		json_object_iter_next(&it);
 	}

--- a/tests/test_parse.c
+++ b/tests/test_parse.c
@@ -215,7 +215,7 @@ static void do_clear_serializer(json_object *jso)
 }
 
 static int clear_serializer(json_object *jso, int flags, json_object *parent_jso,
-                            const char *jso_key, size_t *jso_index, void *userarg)
+                            const struct lh_string *jso_key, size_t *jso_index, void *userarg)
 {
 	if (jso)
 		json_object_set_serializer(jso, NULL, NULL, NULL);

--- a/tests/test_visit.c
+++ b/tests/test_visit.c
@@ -68,17 +68,17 @@ int main(void)
 	return 0;
 }
 
-static int emit_object(json_object *jso, int flags, json_object *parent_jso, const char *jso_key,
-                       size_t *jso_index, void *userarg)
+static int emit_object(json_object *jso, int flags, json_object *parent_jso,
+                       const struct lh_string *jso_key, size_t *jso_index, void *userarg)
 {
 	printf("flags: 0x%x, key: %s, index: %ld, value: %s\n", flags,
-	       (jso_key ? jso_key : "(null)"), (jso_index ? (long)*jso_index : -1L),
+	       (jso_key ? lh_string_data(jso_key) : "(null)"), (jso_index ? (long)*jso_index : -1L),
 	       json_object_to_json_string(jso));
 	return JSON_C_VISIT_RETURN_CONTINUE;
 }
 
-static int skip_arrays(json_object *jso, int flags, json_object *parent_jso, const char *jso_key,
-                       size_t *jso_index, void *userarg)
+static int skip_arrays(json_object *jso, int flags, json_object *parent_jso,
+                       const struct lh_string *jso_key, size_t *jso_index, void *userarg)
 {
 	(void)emit_object(jso, flags, parent_jso, jso_key, jso_index, userarg);
 	if (json_object_get_type(jso) == json_type_array)
@@ -86,16 +86,16 @@ static int skip_arrays(json_object *jso, int flags, json_object *parent_jso, con
 	return JSON_C_VISIT_RETURN_CONTINUE;
 }
 
-static int pop_and_stop(json_object *jso, int flags, json_object *parent_jso, const char *jso_key,
-                        size_t *jso_index, void *userarg)
+static int pop_and_stop(json_object *jso, int flags, json_object *parent_jso,
+                        const struct lh_string *jso_key, size_t *jso_index, void *userarg)
 {
 	(void)emit_object(jso, flags, parent_jso, jso_key, jso_index, userarg);
-	if (jso_key != NULL && strcmp(jso_key, "subobj1") == 0)
+	if (jso_key != NULL && strcmp(lh_string_data(jso_key), "subobj1") == 0)
 	{
 		printf("POP after handling subobj1\n");
 		return JSON_C_VISIT_RETURN_POP;
 	}
-	if (jso_key != NULL && strcmp(jso_key, "obj3") == 0)
+	if (jso_key != NULL && strcmp(lh_string_data(jso_key), "obj3") == 0)
 	{
 		printf("STOP after handling obj3\n");
 		return JSON_C_VISIT_RETURN_STOP;
@@ -103,11 +103,11 @@ static int pop_and_stop(json_object *jso, int flags, json_object *parent_jso, co
 	return JSON_C_VISIT_RETURN_CONTINUE;
 }
 
-static int err_on_subobj2(json_object *jso, int flags, json_object *parent_jso, const char *jso_key,
-                          size_t *jso_index, void *userarg)
+static int err_on_subobj2(json_object *jso, int flags, json_object *parent_jso,
+                          const struct lh_string *jso_key, size_t *jso_index, void *userarg)
 {
 	(void)emit_object(jso, flags, parent_jso, jso_key, jso_index, userarg);
-	if (jso_key != NULL && strcmp(jso_key, "subobj2") == 0)
+	if (jso_key != NULL && strcmp(lh_string_data(jso_key), "subobj2") == 0)
 	{
 		printf("ERROR after handling subobj1\n");
 		return JSON_C_VISIT_RETURN_ERROR;
@@ -115,8 +115,8 @@ static int err_on_subobj2(json_object *jso, int flags, json_object *parent_jso, 
 	return JSON_C_VISIT_RETURN_CONTINUE;
 }
 
-static int pop_array(json_object *jso, int flags, json_object *parent_jso, const char *jso_key,
-                     size_t *jso_index, void *userarg)
+static int pop_array(json_object *jso, int flags, json_object *parent_jso,
+                     const struct lh_string *jso_key, size_t *jso_index, void *userarg)
 {
 	(void)emit_object(jso, flags, parent_jso, jso_key, jso_index, userarg);
 	if (jso_index != NULL && (*jso_index == 0))
@@ -127,8 +127,8 @@ static int pop_array(json_object *jso, int flags, json_object *parent_jso, const
 	return JSON_C_VISIT_RETURN_CONTINUE;
 }
 
-static int stop_array(json_object *jso, int flags, json_object *parent_jso, const char *jso_key,
-                      size_t *jso_index, void *userarg)
+static int stop_array(json_object *jso, int flags, json_object *parent_jso,
+                      const struct lh_string *jso_key, size_t *jso_index, void *userarg)
 {
 	(void)emit_object(jso, flags, parent_jso, jso_key, jso_index, userarg);
 	if (jso_index != NULL && (*jso_index == 0))
@@ -139,11 +139,11 @@ static int stop_array(json_object *jso, int flags, json_object *parent_jso, cons
 	return JSON_C_VISIT_RETURN_CONTINUE;
 }
 
-static int err_return(json_object *jso, int flags, json_object *parent_jso, const char *jso_key,
-                      size_t *jso_index, void *userarg)
+static int err_return(json_object *jso, int flags, json_object *parent_jso,
+                      const struct lh_string *jso_key, size_t *jso_index, void *userarg)
 {
 	printf("flags: 0x%x, key: %s, index: %ld, value: %s\n", flags,
-	       (jso_key ? jso_key : "(null)"), (jso_index ? (long)*jso_index : -1L),
+	       (jso_key ? lh_string_data(jso_key) : "(null)"), (jso_index ? (long)*jso_index : -1L),
 	       json_object_to_json_string(jso));
 	return 100;
 }


### PR DESCRIPTION
This allows keys to contain null characters (`\u0000`). While there were no changes made to the `json_object_object_*` functions, there were some changes needed for some of the others.

Before merging this, I'd want to go through and rename a fair amount of symbols that are badly named (such as moving and renaming one of the types I added, `struct lh_string`). Before I go through that effort, though, I'd want to know what, if anything, I should change in what I have written.

This tries to fix issue #108 (merge request #528 will no longer be needed)