### PR TITLE
Fixed cmake command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ sudo apt install valgrind # optional
 $ git clone https://github.com/json-c/json-c.git
 $ mkdir json-c-build
 $ cd json-c-build
-$ cmake ../json-c   # See CMake section below for custom arguments
+$ cmake ../   # See CMake section below for custom arguments
 ```
 
 Note: it's also possible to put your build directory inside the json-c


### PR DESCRIPTION
The directory `json-c` in the root of this repository does not exist, and just running `cmake` in the root works fine