### PR TITLE
Fix use-after-free in json_tokener_new_ex()

### DIFF
--- a/json_tokener.c
+++ b/json_tokener.c
@@ -164,8 +164,8 @@ struct json_tokener *json_tokener_new_ex(int depth)
 	tok->pb = printbuf_new();
 	if (!tok->pb)
 	{
-		free(tok);
 		free(tok->stack);
+		free(tok);
 		return NULL;
 	}
 	tok->max_depth = depth;


### PR DESCRIPTION
The failure path taken in the event of printbuf_new() returning NULL
calls free() on tok->stack after already having freed tok. Swap the
order of the two calls to fix an obvious memory access violation.

Fixes: bcb6d7d3474b ("Handle allocation failure in json_tokener_new_ex")
Signed-off-by: Juuso Alasuutari <juuso.alasuutari@gmail.com>