### PR TITLE
Really use prefix JSON_C_OBJECT_ADD_

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,8 +2,11 @@
 Next Release 0.16
 =====================
 
-...no changes yet...
-
+Significant changes and bug fixes
+---------------------------------
+* Introduction of constant JSON_C_OBJECT_ADD_CONSTANT_KEY
+   as a replacement of JSON_C_OBJECT_KEY_IS_CONSTANT,
+   JSON_C_OBJECT_KEY_IS_CONSTANT becoming legacy.
 
 ***
 

--- a/json_object.c
+++ b/json_object.c
@@ -607,7 +607,7 @@ int json_object_object_add_ex(struct json_object *jso, const char *const key,
 	if (!existing_entry)
 	{
 		const void *const k =
-		    (opts & JSON_C_OBJECT_KEY_IS_CONSTANT) ? (const void *)key : strdup(key);
+		    (opts & JSON_C_OBJECT_ADD_CONSTANT_KEY) ? (const void *)key : strdup(key);
 		if (k == NULL)
 			return -1;
 		return lh_table_insert_w_hash(JC_OBJECT(jso)->c_object, k, val, hash, opts);

--- a/json_object.h
+++ b/json_object.h
@@ -100,9 +100,17 @@ extern "C" {
  * key is given as a real constant value in the function
  * call, e.g. as in
  *   json_object_object_add_ex(obj, "ip", json,
- *       JSON_C_OBJECT_KEY_IS_CONSTANT);
+ *       JSON_C_OBJECT_ADD_CONSTANT_KEY);
  */
-#define JSON_C_OBJECT_KEY_IS_CONSTANT (1 << 2)
+#define JSON_C_OBJECT_ADD_CONSTANT_KEY (1 << 2)
+/**
+ * This flag is an alias to JSON_C_OBJECT_ADD_CONSTANT_KEY.
+ * Historically, this flag was used first and the new name
+ * JSON_C_OBJECT_ADD_CONSTANT_KEY was introduced for version
+ * 0.16.00 in order to have regular naming.
+ * Use of this flag is now legacy.
+ */
+#define JSON_C_OBJECT_KEY_IS_CONSTANT  JSON_C_OBJECT_ADD_CONSTANT_KEY
 
 /**
  * Set the global value of an option, which will apply to all

--- a/linkhash.c
+++ b/linkhash.c
@@ -546,7 +546,7 @@ int lh_table_resize(struct lh_table *t, int new_size)
 		unsigned long h = lh_get_hash(new_t, ent->k);
 		unsigned int opts = 0;
 		if (ent->k_is_constant)
-			opts = JSON_C_OBJECT_KEY_IS_CONSTANT;
+			opts = JSON_C_OBJECT_ADD_CONSTANT_KEY;
 		if (lh_table_insert_w_hash(new_t, ent->k, ent->v, h, opts) != 0)
 		{
 			lh_table_free(new_t);
@@ -599,7 +599,7 @@ int lh_table_insert_w_hash(struct lh_table *t, const void *k, const void *v, con
 	}
 
 	t->table[n].k = k;
-	t->table[n].k_is_constant = (opts & JSON_C_OBJECT_KEY_IS_CONSTANT);
+	t->table[n].k_is_constant = (opts & JSON_C_OBJECT_ADD_CONSTANT_KEY);
 	t->table[n].v = v;
 	t->count++;
 

--- a/linkhash.h
+++ b/linkhash.h
@@ -231,7 +231,7 @@ extern int lh_table_insert(struct lh_table *t, const void *k, const void *v);
  * @param k a pointer to the key to insert.
  * @param v a pointer to the value to insert.
  * @param h hash value of the key to insert
- * @param opts if set to JSON_C_OBJECT_KEY_IS_CONSTANT, sets lh_entry.k_is_constant
+ * @param opts if set to JSON_C_OBJECT_ADD_CONSTANT_KEY, sets lh_entry.k_is_constant
  *             so t's free function knows to avoid freeing the key.
  */
 extern int lh_table_insert_w_hash(struct lh_table *t, const void *k, const void *v,


### PR DESCRIPTION
The description of json_object_object_add_ex tells to
look at the flags JSON_C_OBJECT_ADD_* but it is not
for JSON_C_OBJECT_KEY_IS_CONSTANT.