### PR TITLE
Newer appveyor config for VS2022 etc...

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,31 +1,45 @@
 version: '{branch}.{build}'
-os: Windows Server 2012 R2
+
+image:
+  # VS2015 also used for earlier VS builds
+  # aka os: Windows Server 2012 R2
+  - Visual Studio 2015
+  # aka os: Windows Server 2016
+  - Visual Studio 2017
+  # aka os: Windows Server 2019
+  - Visual Studio 2019
 
 platform: x64
 
-# There should be a better way to set-up a build matrix.
+for:
+-
+  matrix:
+    only:
+      - image: Visual Studio 2015
+
+  environment:
+    matrix:
+      - b_toolset: Windows7.1SDK
+        b_config: Debug
+
+      - b_toolset: v120
+        b_config: Debug
+
+      - b_toolset: v140
+        b_config: Debug
+
+  build_script:
+    - cmake -T %b_toolset% -DCMAKE_BUILD_TYPE=%b_config% -DCMAKE_INSTALL_PREFIX=t_install .
+    - cmake --build . --target install
+
 environment:
   matrix:
-    - b_toolset: Windows7.1SDK
-      b_config: Debug
+    - b_config: Debug
 
-    - b_toolset: Windows7.1SDK
-      b_config: Release
-
-    - b_toolset: v120
-      b_config: Debug
-
-    - b_toolset: v120
-      b_config: Release
-
-    - b_toolset: v140
-      b_config: Debug
-
-    - b_toolset: v140
-      b_config: Release
+    - b_config: Release
 
 build_script:
-- cmake -T %b_toolset% -DCMAKE_BUILD_TYPE=%b_config% -DCMAKE_INSTALL_PREFIX=t_install .
+- cmake -DCMAKE_BUILD_TYPE=%b_config% -DCMAKE_INSTALL_PREFIX=t_install .
 - cmake --build . --target install
 
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,11 @@ build_script:
 
 matrix:
   exclude:
+    #  Skip release builds for all except the newest image
+    - image: Visual Studio 2015
+      configuration: Release
+
+    # In the "old" image, new toolsets aren't available:
     - image: Visual Studio 2015
       b_toolset: v141
 
@@ -49,6 +54,12 @@ matrix:
       b_toolset: v143
 
     # ----
+
+    - image: Visual Studio 2017
+      configuration: Release
+
+    # In the "new" images, exclude all toolsets except the relevant
+    #  one for that image:
 
     - image: Visual Studio 2017
       b_toolset: Windows7.1SDK
@@ -66,6 +77,9 @@ matrix:
       b_toolset: v143
 
     # ----
+
+    - image: Visual Studio 2019
+      configuration: Release
 
     - image: Visual Studio 2019
       b_toolset: Windows7.1SDK
@@ -101,8 +115,8 @@ matrix:
 
 after_build:
 - cd t_install
-- 7z a ../json-c.win32.%b_toolset%.%b_config%.zip *
+- 7z a ../json-c.win32.%b_toolset%.%CONFIGURATION%.zip *
 
 artifacts:
-- path: json-c.win32.%b_toolset%.%b_config%.zip
-  name: json-c.win32.%b_toolset%.%b_config%.zip
+- path: json-c.win32.%b_toolset%.%CONFIGURATION%.zip
+  name: json-c.win32.%b_toolset%.%CONFIGURATION%.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,42 +5,99 @@ image:
   # aka os: Windows Server 2012 R2
   - Visual Studio 2015
   # aka os: Windows Server 2016
+# b_toolset: v141
   - Visual Studio 2017
   # aka os: Windows Server 2019
+# b_toolset: v142
   - Visual Studio 2019
+# b_toolset: v143
+  - Visual Studio 2022
 
 platform: x64
 
-for:
--
-  matrix:
-    only:
-      - image: Visual Studio 2015
-
-  environment:
-    matrix:
-      - b_toolset: Windows7.1SDK
-        b_config: Debug
-
-      - b_toolset: v120
-        b_config: Debug
-
-      - b_toolset: v140
-        b_config: Debug
-
-  build_script:
-    - cmake -T %b_toolset% -DCMAKE_BUILD_TYPE=%b_config% -DCMAKE_INSTALL_PREFIX=t_install .
-    - cmake --build . --target install
-
 environment:
   matrix:
-    - b_config: Debug
+    - b_toolset: Windows7.1SDK
 
-    - b_config: Release
+    - b_toolset: v120
+
+    - b_toolset: v140
+
+    - b_toolset: v141
+
+    - b_toolset: v142
+
+    - b_toolset: v143
+
+configuration:
+  - Debug
+  - Release
 
 build_script:
-- cmake -DCMAKE_BUILD_TYPE=%b_config% -DCMAKE_INSTALL_PREFIX=t_install .
+- cmake -T %b_toolset% -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_INSTALL_PREFIX=t_install .
 - cmake --build . --target install
+
+matrix:
+  exclude:
+    - image: Visual Studio 2015
+      b_toolset: v141
+
+    - image: Visual Studio 2015
+      b_toolset: v142
+
+    - image: Visual Studio 2015
+      b_toolset: v143
+
+    # ----
+
+    - image: Visual Studio 2017
+      b_toolset: Windows7.1SDK
+
+    - image: Visual Studio 2017
+      b_toolset: v120
+
+    - image: Visual Studio 2017
+      b_toolset: v140
+
+    - image: Visual Studio 2017
+      b_toolset: v142
+
+    - image: Visual Studio 2017
+      b_toolset: v143
+
+    # ----
+
+    - image: Visual Studio 2019
+      b_toolset: Windows7.1SDK
+
+    - image: Visual Studio 2019
+      b_toolset: v120
+
+    - image: Visual Studio 2019
+      b_toolset: v140
+
+    - image: Visual Studio 2019
+      b_toolset: v141
+
+    - image: Visual Studio 2019
+      b_toolset: v143
+
+    # ----
+
+    - image: Visual Studio 2022
+      b_toolset: Windows7.1SDK
+
+    - image: Visual Studio 2022
+      b_toolset: v120
+
+    - image: Visual Studio 2022
+      b_toolset: v140
+
+    - image: Visual Studio 2022
+      b_toolset: v141
+
+    - image: Visual Studio 2022
+      b_toolset: v142
 
 after_build:
 - cd t_install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,20 @@
 version: '{branch}.{build}'
 
 image:
+# b_toolset: v143
+  - Visual Studio 2022
+
   # VS2015 also used for earlier VS builds
   # aka os: Windows Server 2012 R2
   - Visual Studio 2015
+
   # aka os: Windows Server 2016
 # b_toolset: v141
   - Visual Studio 2017
+
   # aka os: Windows Server 2019
 # b_toolset: v142
   - Visual Studio 2019
-# b_toolset: v143
-  - Visual Studio 2022
 
 platform: x64
 


### PR DESCRIPTION
Update the appveyor config to specify "image" instead of just "os", and build for VS2017, VS2019 and VS2022.