### PR TITLE
Add policy_max to minimum required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Many projects still are stuck using CMake 2.8 is several places so it's good to provide backward support too. This is
 # specially true in old embedded systems (OpenWRT and friends) where CMake isn't necessarily upgraded.
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8...3.16)
 
 if(POLICY CMP0048)
 	cmake_policy(SET CMP0048 NEW)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8)  # see ../CMakeLists.txt for why 2.8
+cmake_minimum_required(VERSION 2.8...3.16)  # see ../CMakeLists.txt for why 2.8
 
 if(POLICY CMP0075)
     cmake_policy(SET CMP0075 NEW)


### PR DESCRIPTION
This PR adds [`policy_max`](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html) specifier to `cmake_minimum_required`, that allows CMake to use newer policy set than CMake 2.8, up to CMake 3.16.

As CMake seems to be [dropping the support of older version](https://cmake.org/cmake/help/latest/release/3.19.html#deprecated-and-removed-features), according to a deprecation warning, it will stop working with the current set up. (I don't know the exact timeline, though).
With this PR, CMake should keep working even after it drops 2.8 support, using a newer policy set.

As a down side of this PR, this allows CMake to use any of the policy set between 2.8 and 3.16, that may make the maintenance harder. That is, we may overlook to add a 2.8-incompatible code until we try it on CMake 2.8.

WDYT?