### PR TITLE
json_escape_str(): avoid harmless unsigned integer overflow

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -180,8 +180,9 @@ static int json_escape_str(struct printbuf *pb, const char *str, size_t len, int
 {
 	size_t pos = 0, start_offset = 0;
 	unsigned char c;
-	while (len--)
+	while (len)
 	{
+		--len;
 		c = str[pos];
 		switch (c)
 		{


### PR DESCRIPTION
Current behaviour is perfectly valid, since wrap-over upon overflow is
well defined behaviour for unsigned types, but it is nevertheless nice to be
able to build with -fsanitize=undefined,unsigned-integer-overflow

There is no significant effect on the generated assembly as can be seen
on the diff of objdump -d output on a optimized build (the compiler
just decided to switch the order of a comparison):

```
@@ -135,8 +135,8 @@
  1d0:	0f 84 70 ff ff ff    	je     146 <json_escape_str+0x146>
  1d6:	4c 3b 24 24          	cmp    (%rsp),%r12
  1da:	0f 85 2d ff ff ff    	jne    10d <json_escape_str+0x10d>
- 1e0:	49 39 f4             	cmp    %rsi,%r12
- 1e3:	0f 87 b7 00 00 00    	ja     2a0 <json_escape_str+0x2a0>
+ 1e0:	4c 39 e6             	cmp    %r12,%rsi
+ 1e3:	0f 82 b7 00 00 00    	jb     2a0 <json_escape_str+0x2a0>
  1e9:	48 8b 44 24 18       	mov    0x18(%rsp),%rax
  1ee:	64 48 33 04 25 28 00 	xor    %fs:0x28,%rax
  1f5:	00 00
```