### PR TITLE
json_object_copy_serializer_data(): add assertion

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -1588,6 +1588,7 @@ static int json_object_copy_serializer_data(struct json_object *src, struct json
 	if (dst->_to_json_string == json_object_userdata_to_json_string ||
 	    dst->_to_json_string == _json_object_userdata_to_json_string)
 	{
+		assert(src->_userdata);
 		dst->_userdata = strdup(src->_userdata);
 	}
 	// else if ... other supported serializers ...


### PR DESCRIPTION
This makes Coverity Scan happier since it believes that the initial
check ``if (!src->_userdata && !src->_user_delete)`` could mean that
src->_user_data may be nullptr.