### PR TITLE
Close file on error path.

### DIFF
--- a/random_seed.c
+++ b/random_seed.c
@@ -237,13 +237,15 @@ static int get_dev_random_seed(int *seed)
 	}
 
 	ssize_t nread = read(fd, seed, sizeof(*seed));
+
+	close(fd);
+
 	if (nread != sizeof(*seed))
 	{
 		fprintf(stderr, "error short read %s: %s", dev_random_file, strerror(errno));
 		return -1;
 	}
 
-	close(fd);
 	return 0;
 }
 


### PR DESCRIPTION
The file was only be closed when there was no error and
was being left open when there was an error. By moving
the close(fd) statement out of the if-clause, the file
can be close regardless if there is an error or not.
After the file is closed, it can be checked for errors.

shout out to:
[c3h2_ctf](https://twitter.com/c3h2_ctf)