### PR TITLE
sprintbuf(): test for all vsnprintf error values

### DIFF
--- a/printbuf.c
+++ b/printbuf.c
@@ -143,7 +143,7 @@ int sprintbuf(struct printbuf *p, const char *msg, ...)
 	 * if output is truncated whereas some return the number of bytes that
 	 * would have been written - this code handles both cases.
 	 */
-	if (size == -1 || size > 127)
+	if (size < 0 || size > 127)
 	{
 		va_start(ap, msg);
 		if ((size = vasprintf(&t, msg, ap)) < 0)


### PR DESCRIPTION
The POSIX specification states that vsnprintf returns "a negative value"
in case of error, but the code checks explicitly only for -1.

Shoutout to [C3H2-CTF](https://twitter.com/c3h2_ctf).