### PR TITLE
printbuf_memset(): set gaps to zero

### DIFF
--- a/printbuf.c
+++ b/printbuf.c
@@ -120,6 +120,8 @@ int printbuf_memset(struct printbuf *pb, int offset, int charvalue, int len)
 			return -1;
 	}
 
+	if (pb->bpos < offset)
+		memset(pb->buf + pb->bpos, '\0', offset - pb->bpos);
 	memset(pb->buf + offset, charvalue, len);
 	if (pb->bpos < size_needed)
 		pb->bpos = size_needed;


### PR DESCRIPTION
It is possible to have a printbuf with "gaps", i.e. areas within the
print buffer which have not been initialized by using printbuf_memset.

Always clear memory in such cases.

Example:
```
struct printbuf *pb = printbuf_new();
printbuf_memset(pb, 10, 'a', 2);
```
In this case pb->buf[0] is '\0' but pb->buf[1] up to pb->buf[9] are
not set. The length would be 12 due to successful printbuf_memset.

Shoutout to [C3H2-CTF](https://twitter.com/c3h2_ctf).