### PR TITLE
printbuf: do not allow invalid arguments

### DIFF
--- a/printbuf.c
+++ b/printbuf.c
@@ -91,7 +91,7 @@ static int printbuf_extend(struct printbuf *p, int min_size)
 int printbuf_memappend(struct printbuf *p, const char *buf, int size)
 {
 	/* Prevent signed integer overflows with large buffers. */
-	if (size > INT_MAX - p->bpos - 1)
+	if (size < 0 || size > INT_MAX - p->bpos - 1)
 		return -1;
 	if (p->size <= p->bpos + size + 1)
 	{
@@ -111,7 +111,7 @@ int printbuf_memset(struct printbuf *pb, int offset, int charvalue, int len)
 	if (offset == -1)
 		offset = pb->bpos;
 	/* Prevent signed integer overflows with large buffers. */
-	if (len > INT_MAX - offset)
+	if (len < 0 || offset < -1 || len > INT_MAX - offset)
 		return -1;
 	size_needed = offset + len;
 	if (pb->size < size_needed)


### PR DESCRIPTION
If invalid arguments are passed to printbuf functions return -1 to
protect printbuf internals.

Shoutout to [C3H2-CTF](https://twitter.com/c3h2_ctf).