### PR TITLE
Fix error messages

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -945,14 +945,15 @@ int json_c_set_serialization_double_format(const char *double_format, int global
 		}
 		tls_serialization_float_format = double_format ? strdup(double_format) : NULL;
 #else
-		_json_c_set_last_err("json_c_set_option: not compiled with __thread support\n");
+		_json_c_set_last_err("json_c_set_set_serialization_double_format: not compiled "
+		                     "with __thread support\n");
 		return -1;
 #endif
 	}
 	else
 	{
-		_json_c_set_last_err("json_c_set_option: invalid global_or_thread value: %d\n",
-		                     global_or_thread);
+		_json_c_set_last_err("json_c_set_serialization_double_format: invalid "
+		                     "global_or_thread value: %d\n", global_or_thread);
 		return -1;
 	}
 	return 0;

--- a/json_util.c
+++ b/json_util.c
@@ -91,7 +91,7 @@ struct json_object *json_object_from_fd_ex(int fd, int in_depth)
 
 	if (!(pb = printbuf_new()))
 	{
-		_json_c_set_last_err("json_object_from_file: printbuf_new failed\n");
+		_json_c_set_last_err("json_object_from_fd_ex: printbuf_new failed\n");
 		return NULL;
 	}
 
@@ -101,7 +101,7 @@ struct json_object *json_object_from_fd_ex(int fd, int in_depth)
 	if (!tok)
 	{
 		_json_c_set_last_err(
-		    "json_object_from_fd: unable to allocate json_tokener(depth=%d): %s\n", depth,
+		    "json_object_from_fd_ex: unable to allocate json_tokener(depth=%d): %s\n", depth,
 		    strerror(errno));
 		printbuf_free(pb);
 		return NULL;
@@ -113,7 +113,7 @@ struct json_object *json_object_from_fd_ex(int fd, int in_depth)
 	}
 	if (ret < 0)
 	{
-		_json_c_set_last_err("json_object_from_fd: error reading fd %d: %s\n", fd,
+		_json_c_set_last_err("json_object_from_fd_ex: error reading fd %d: %s\n", fd,
 		                     strerror(errno));
 		json_tokener_free(tok);
 		printbuf_free(pb);
@@ -137,8 +137,8 @@ struct json_object *json_object_from_file(const char *filename)
 
 	if ((fd = open(filename, O_RDONLY)) < 0)
 	{
-		_json_c_set_last_err("json_object_from_file: error opening file %s: %s\n", filename,
-		                     strerror(errno));
+		_json_c_set_last_err("json_object_from_file: error opening file %s: %s\n",
+		                     filename, strerror(errno));
 		return NULL;
 	}
 	obj = json_object_from_fd(fd);
@@ -155,14 +155,14 @@ int json_object_to_file_ext(const char *filename, struct json_object *obj, int f
 
 	if (!obj)
 	{
-		_json_c_set_last_err("json_object_to_file: object is null\n");
+		_json_c_set_last_err("json_object_to_file_ext: object is null\n");
 		return -1;
 	}
 
 	if ((fd = open(filename, O_WRONLY | O_TRUNC | O_CREAT, 0644)) < 0)
 	{
-		_json_c_set_last_err("json_object_to_file: error opening file %s: %s\n", filename,
-		                     strerror(errno));
+		_json_c_set_last_err("json_object_to_file_ext: error opening file %s: %s\n",
+		                     filename, strerror(errno));
 		return -1;
 	}
 	ret = _json_object_to_fd(fd, obj, flags, filename);
@@ -202,7 +202,7 @@ static int _json_object_to_fd(int fd, struct json_object *obj, int flags, const 
 	{
 		if ((ret = write(fd, json_str + wpos, wsize - wpos)) < 0)
 		{
-			_json_c_set_last_err("json_object_to_file: error writing file %s: %s\n",
+			_json_c_set_last_err("json_object_to_fd: error writing file %s: %s\n",
 			                     filename, strerror(errno));
 			return -1;
 		}


### PR DESCRIPTION
Error messages did not reflect actual function names.

This pull request is separated from documentation fixes in case these
messages are supposed to look this way for historical reasons or
compatibility.

Shoutout to [C3H2-CTF](https://twitter.com/c3h2_ctf).