### PR TITLE
json_object_from_fd_ex: fail if file is too large

### DIFF
--- a/tests/test_util_file.expected
+++ b/tests/test_util_file.expected
@@ -4,7 +4,7 @@ OK: correctly unable to parse contents of valid_nested.json with low max depth: 
 
 OK: json_object_from_file(./not_present.json) correctly returned NULL: json_object_from_file: error opening file ./not_present.json: ERRNO=ENOENT
 
-OK: json_object_from_fd(closed_fd), expecting NULL, EBADF, got:NULL, json_object_from_fd: error reading fd 10: ERRNO=EBADF
+OK: json_object_from_fd(closed_fd), expecting NULL, EBADF, got:NULL, json_object_from_fd_ex: error reading fd 10: ERRNO=EBADF
 
 OK: json_object_to_file(json.out, jso)=0
 file[json.out], size=336, contents={"foo":1234,"foo1":"abcdefghijklmnopqrstuvwxyz","foo2":"abcdefghijklmnopqrstuvwxyz","foo3":"abcdefghijklmnopqrstuvwxyz","foo4":"abcdefghijklmnopqrstuvwxyz","foo5":"abcdefghijklmnopqrstuvwxyz","foo6":"abcdefghijklmnopqrstuvwxyz","foo7":"abcdefghijklmnopqrstuvwxyz","foo8":"abcdefghijklmnopqrstuvwxyz","foo9":"abcdefghijklmnopqrstuvwxyz"}


### PR DESCRIPTION
If the input file is too large to fit into a printbuf then return an
error value instead of silently truncating the parsed content.

This introduces errno handling into printbuf to distinguish between an
input file being too large and running out of memory.

Shoutout to [C3H2-CTF](https://twitter.com/c3h2_ctf).