### PR TITLE
Code style: removed unneeded double-quotes

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -38,7 +38,7 @@
 #define is_plain_digit(c) ((c) >= '0' && (c) <= '9')
 
 #if SIZEOF_LONG_LONG != SIZEOF_INT64_T
-#error "The long long type isn't 64-bits"
+#error The long long type isn't 64-bits
 #endif
 
 #ifndef SSIZE_T_MAX


### PR DESCRIPTION
this way it complies with the other #error usages

shoutout to [c3h2-ctf](https://twitter.com/c3h2_ctf)