### PR TITLE
fix fallthough warning

### DIFF
--- a/apps/json_parse.c
+++ b/apps/json_parse.c
@@ -167,7 +167,7 @@ int main(int argc, char **argv)
 		case 'f': formatted_output = 1; break;
 		case 'n': show_output = 0; break;
 		case 's': strict_mode = 1; break;
-		case 'h': usage(argv[0], 0, NULL);
+		case 'h': usage(argv[0], 0, NULL); exit(EXIT_SUCCESS);
 		default: /* '?' */ usage(argv[0], EXIT_FAILURE, "Unknown arguments");
 		}
 	}


### PR DESCRIPTION
Hello,

I've try to fix a fall-though error with gcc (11 on my machine).
Instead of having a fall-though comment, as gcc would advice,
I've made an early exit, as using -h is generally expected to just print
help and exit.

note that if you want me to keep old help behavior I can modify this patch too.

fix #770

Signed-off-by: Matthias Gatto <matthias.gatto@protonmail.com>