### PR TITLE
add JSON_C_TO_STRING_COLOR option

### DIFF
--- a/apps/json_parse.c
+++ b/apps/json_parse.c
@@ -38,6 +38,7 @@
 static int formatted_output = JSON_C_TO_STRING_SPACED;
 static int show_output = 1;
 static int strict_mode = 0;
+static int color = 0;
 static const char *fname = NULL;
 
 #ifndef HAVE_JSON_TOKENER_GET_PARSE_END
@@ -141,7 +142,7 @@ static int showobj(struct json_object *new_obj)
 	if (show_output)
 	{
 		const char *output;
-		output = json_object_to_json_string_ext(new_obj, formatted_output);
+		output = json_object_to_json_string_ext(new_obj, formatted_output | color);
 		printf("%s\n", output);
 	}
 
@@ -160,6 +161,7 @@ static void usage(const char *argv0, int exitval, const char *errmsg)
 	fprintf(fp, "  -f - Format the output to stdout with JSON_C_TO_STRING_PRETTY (default is JSON_C_TO_STRING_SPACED)\n");
 	fprintf(fp, "  -F - Format the output to stdout with <arg>, e.g. 0 for JSON_C_TO_STRING_PLAIN\n");
 	fprintf(fp, "  -n - No output\n");
+	fprintf(fp, "  -c - color\n");
 	fprintf(fp, "  -s - Parse in strict mode, flags:\n");
 	fprintf(fp, "       JSON_TOKENER_STRICT|JSON_TOKENER_ALLOW_TRAILING_CHARS\n");
 	fprintf(fp, " Diagnostic information will be emitted to stderr\n");
@@ -173,7 +175,7 @@ int main(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt(argc, argv, "fF:hns")) != -1)
+	while ((opt = getopt(argc, argv, "fF:hnsc")) != -1)
 	{
 		switch (opt)
 		{
@@ -181,6 +183,7 @@ int main(int argc, char **argv)
 		case 'F': formatted_output = atoi(optarg); break;
 		case 'n': show_output = 0; break;
 		case 's': strict_mode = 1; break;
+		case 'c': color = JSON_C_TO_STRING_COLOR; break;
 		case 'h': usage(argv[0], 0, NULL);
 		default: /* '?' */ usage(argv[0], EXIT_FAILURE, "Unknown arguments");
 		}

--- a/json_object.h
+++ b/json_object.h
@@ -75,6 +75,15 @@ extern "C" {
 #define JSON_C_TO_STRING_NOSLASHESCAPE (1 << 4)
 
 /**
+ * A flag for the json_object_to_json_string_ext() and
+ * json_object_to_file_ext() functions which causes
+ * the output to be formatted.
+ *
+ * Use color for printing json.
+ */
+#define JSON_C_TO_STRING_COLOR (1 << 5)
+
+/**
  * A flag for the json_object_object_add_ex function which
  * causes the value to be added without a check if it already exists.
  * Note: it is the responsibility of the caller to ensure that no


### PR DESCRIPTION
This option enable color in json_object_to_json_string_ext.
I've try to made something similar to jq output,
but I color true/false and null in purple,
as it's what is common color scheme used in programing language in emacs.

also add a '-c' option into json_parser to test it.

note: that I could have done a color() function similar to
what is done with indent(), but as the code is pretty small
I've keep it as it. so if you want  me to use a subfunction
tell me and I'll do it.

Signed-off-by: Matthias Gatto <matthias.gatto@protonmail.com>