### PR TITLE
Fix typos found by codespell

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1103,7 +1103,7 @@ HTML_STYLESHEET        =
 # cascading style sheets that are included after the standard style sheets
 # created by doxygen. Using this option one can overrule certain style aspects.
 # This is preferred over using HTML_STYLESHEET since it does not replace the
-# standard style sheet and is therefor more robust against future updates.
+# standard style sheet and is therefore more robust against future updates.
 # Doxygen will copy the style sheet files to the output directory.
 # Note: The order of the extra stylesheet files is of importance (e.g. the last
 # stylesheet in the list overrules the setting of the previous ones in the

--- a/tests/test_deep_copy.c
+++ b/tests/test_deep_copy.c
@@ -22,7 +22,7 @@ static const char *json_str1 =
     "            \"number\": 16446744073709551615,"
     "            \"title\": \"S\","
     "            \"null_obj\": null, "
-    "            \"exixt\": false,"
+    "            \"exist\": false,"
     "            \"quantity\":20,"
     "            \"univalent\":19.8,"
     "            \"GlossList\": {"
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
 	assert(0 == json_object_deep_copy(src2, &dst2, NULL));
 	assert(0 == json_object_deep_copy(src3, &dst3, NULL));
 
-	printf("PASSED - all json_object_deep_copy() returned succesful\n");
+	printf("PASSED - all json_object_deep_copy() returned successful\n");
 
 	assert(-1 == json_object_deep_copy(src1, &dst1, NULL));
 	assert(errno == EINVAL);
@@ -151,7 +151,7 @@ int main(int argc, char **argv)
 	assert(1 == json_object_equal(src2, dst2));
 	assert(1 == json_object_equal(src3, dst3));
 
-	printf("PASSED - all json_object_equal() tests returned succesful\n");
+	printf("PASSED - all json_object_equal() tests returned successful\n");
 
 	assert(0 == strcmp(json_object_to_json_string_ext(src1, JSON_C_TO_STRING_PRETTY),
 	                   json_object_to_json_string_ext(dst1, JSON_C_TO_STRING_PRETTY)));

--- a/tests/test_deep_copy.expected
+++ b/tests/test_deep_copy.expected
@@ -1,7 +1,7 @@
 PASSED - loaded input data
-PASSED - all json_object_deep_copy() returned succesful
+PASSED - all json_object_deep_copy() returned successful
 PASSED - all json_object_deep_copy() returned EINVAL for non-null pointer
-PASSED - all json_object_equal() tests returned succesful
+PASSED - all json_object_equal() tests returned successful
 PASSED - comparison of string output
 PASSED - trying to overrwrite an object that has refcount > 1
 Printing JSON objects for visual inspection
@@ -14,7 +14,7 @@ Printing JSON objects for visual inspection
       "number":16446744073709551615,
       "title":"S",
       "null_obj":null,
-      "exixt":false,
+      "exist":false,
       "quantity":20,
       "univalent":19.8,
       "GlossList":{


### PR DESCRIPTION
Do not fix typos from past commits found in release notes.
```
$ codespell 
./issues_closed_for_0.15.md:80: informations ==> information
./issues_closed_for_0.14.md:98: valuse ==> values, value
./issues_closed_for_0.14.md:104: upate ==> update
./issues_closed_for_0.14.md:132: retuns ==> returns
./issues_closed_for_0.13.md:154: successed ==> succeeded, success, successful
./issues_closed_for_0.13.md:160: doubel ==> double
./issues_closed_for_0.13.md:178: representaion ==> representation
$ 
```