### PR TITLE
Fix build with clang-15+

### DIFF
--- a/json_inttypes.h
+++ b/json_inttypes.h
@@ -21,4 +21,9 @@
 
 #endif
 
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 #endif

--- a/json_pointer.c
+++ b/json_pointer.c
@@ -44,6 +44,7 @@ static void string_replace_all_occurrences_with_char(char *s, const char *occur,
 static int is_valid_index(struct json_object *jo, const char *path, size_t *idx)
 {
 	size_t i, len = strlen(path);
+	long int idx_val = -1;
 	/* this code-path optimizes a bit, for when we reference the 0-9 index range
 	 * in a JSON array and because leading zeros not allowed
 	 */
@@ -73,7 +74,7 @@ static int is_valid_index(struct json_object *jo, const char *path, size_t *idx)
 		}
 	}
 
-	long int idx_val = strtol(path, NULL, 10);
+	idx_val = strtol(path, NULL, 10);
 	if (idx_val < 0)
 	{
 		errno = EINVAL;

--- a/json_util.c
+++ b/json_util.c
@@ -60,7 +60,7 @@ static int _json_object_to_fd(int fd, struct json_object *obj, int flags, const 
 
 static char _last_err[256] = "";
 
-const char *json_util_get_last_err()
+const char *json_util_get_last_err(void)
 {
 	if (_last_err[0] == '\0')
 		return NULL;

--- a/tests/test1.c
+++ b/tests/test1.c
@@ -61,7 +61,7 @@ static const char *to_json_string(json_object *obj, int flags)
 #endif
 
 json_object *make_array(void);
-json_object *make_array()
+json_object *make_array(void)
 {
 	json_object *my_array;
 
@@ -77,7 +77,7 @@ json_object *make_array()
 }
 
 void test_array_del_idx(void);
-void test_array_del_idx()
+void test_array_del_idx(void)
 {
 	int rc;
 	size_t ii;
@@ -143,7 +143,7 @@ void test_array_del_idx()
 }
 
 void test_array_list_expand_internal(void);
-void test_array_list_expand_internal()
+void test_array_list_expand_internal(void)
 {
 	int rc;
 	size_t ii;

--- a/tests/test4.c
+++ b/tests/test4.c
@@ -31,7 +31,7 @@ void print_hex(const char *s)
 }
 
 static void test_lot_of_adds(void);
-static void test_lot_of_adds()
+static void test_lot_of_adds(void)
 {
 	int ii;
 	char key[50];

--- a/tests/test_cast.c
+++ b/tests/test_cast.c
@@ -97,7 +97,7 @@ static void getit(struct json_object *new_obj, const char *field)
 	printf("new_obj.%s json_object_get_double()=%f\n", field, json_object_get_double(o));
 }
 
-static void checktype_header()
+static void checktype_header(void)
 {
 	printf("json_object_is_type: %s,%s,%s,%s,%s,%s,%s\n", json_type_to_name(json_type_null),
 	       json_type_to_name(json_type_boolean), json_type_to_name(json_type_double),

--- a/tests/test_charcase.c
+++ b/tests/test_charcase.c
@@ -22,7 +22,7 @@ int main(int argc, char **argv)
 }
 
 /* make sure only lowercase forms are parsed in strict mode */
-static void test_case_parse()
+static void test_case_parse(void)
 {
 	struct json_tokener *tok;
 	json_object *new_obj;

--- a/tests/test_parse.c
+++ b/tests/test_parse.c
@@ -96,7 +96,7 @@ static void single_basic_parse(const char *test_string, int clear_serializer)
 	if (getenv("TEST_PARSE_CHUNKSIZE") != NULL)
 		single_incremental_parse(test_string, clear_serializer);
 }
-static void test_basic_parse()
+static void test_basic_parse(void)
 {
 	single_basic_parse("\"\003\"", 0);
 	single_basic_parse("/* hello */\"foo\"", 0);
@@ -199,7 +199,7 @@ static void test_basic_parse()
 	single_basic_parse("[18446744073709551616]", 1);
 }
 
-static void test_utf8_parse()
+static void test_utf8_parse(void)
 {
 	// json_tokener_parse doesn't support checking for byte order marks.
 	// It's the responsibility of the caller to detect and skip a BOM.
@@ -226,7 +226,7 @@ static int clear_serializer(json_object *jso, int flags, json_object *parent_jso
 	return JSON_C_VISIT_RETURN_CONTINUE;
 }
 
-static void test_verbose_parse()
+static void test_verbose_parse(void)
 {
 	json_object *new_obj;
 	enum json_tokener_error error = json_tokener_success;
@@ -566,7 +566,7 @@ struct incremental_step
     {NULL, -1, -1, json_tokener_success, 0, 0},
 };
 
-static void test_incremental_parse()
+static void test_incremental_parse(void)
 {
 	json_object *new_obj;
 	enum json_tokener_error jerr;

--- a/tests/test_printbuf.c
+++ b/tests/test_printbuf.c
@@ -19,7 +19,7 @@ static void test_printbuf_memset_length(void);
 #define __func__ __FUNCTION__
 #endif
 
-static void test_basic_printbuf_memset()
+static void test_basic_printbuf_memset(void)
 {
 	struct printbuf *pb;
 
@@ -32,7 +32,7 @@ static void test_basic_printbuf_memset()
 	printf("%s: end test\n", __func__);
 }
 
-static void test_printbuf_memset_length()
+static void test_printbuf_memset_length(void)
 {
 	struct printbuf *pb;
 

--- a/tests/test_util_file.c
+++ b/tests/test_util_file.c
@@ -38,7 +38,7 @@ static void test_read_fd_equal(const char *testdir);
 #define PATH_MAX 256
 #endif
 
-static void test_write_to_file()
+static void test_write_to_file(void)
 {
 	json_object *jso;
 
@@ -234,7 +234,7 @@ static void test_read_valid_nested_with_fd(const char *testdir)
 	close(d);
 }
 
-static void test_read_nonexistant()
+static void test_read_nonexistant(void)
 {
 	const char *filename = "./not_present.json";
 
@@ -252,7 +252,7 @@ static void test_read_nonexistant()
 	}
 }
 
-static void test_read_closed()
+static void test_read_closed(void)
 {
 	// Test reading from a closed fd
 	int d = open("/dev/null", O_RDONLY);


### PR DESCRIPTION
Fixes
json_util.c:63:35: error: a function declaration without a prototype is deprecated in all versions of C [-We
rror,-Wstrict-prototypes]
const char *json_util_get_last_err()
                                  ^
                                   void

Signed-off-by: Khem Raj <raj.khem@gmail.com>