### PR TITLE
get_time_seed(): silence warning emitted by Coverity Scan static analyzer

### DIFF
--- a/random_seed.c
+++ b/random_seed.c
@@ -310,6 +310,7 @@ static int get_time_seed(void)
 {
 	DEBUG_SEED("get_time_seed");
 
+	/* coverity[store_truncates_time_t] */
 	return (unsigned)time(NULL) * 433494437;
 }
 #endif


### PR DESCRIPTION
It warns about the return of time() being truncated to 32 bit, which is
not an issue here.
(this warning was emitted because of the https://github.com/OSGeo/gdal
project embedding a copy of libjson-c and running Coverity Scan
analysis)