### PR TITLE
Unnecessary struct declaration and unsafe function usage

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -1047,7 +1047,7 @@ static int json_object_double_to_json_string_format(struct json_object *jso, str
 		{
 			// Ensure it looks like a float, even if snprintf didn't,
 			//  unless a custom format is set to omit the decimal.
-			strcat(buf, ".0");
+			strncat(buf, ".0", 2);
 			size += 2;
 		}
 		if (p && (flags & JSON_C_TO_STRING_NOZERO))

--- a/json_object_private.h
+++ b/json_object_private.h
@@ -20,7 +20,6 @@
 extern "C" {
 #endif
 
-struct json_object;
 #include "json_inttypes.h"
 #include "json_types.h"
 

--- a/vasprintf_compat.h
+++ b/vasprintf_compat.h
@@ -51,7 +51,7 @@ static int vasprintf(char **buf, const char *fmt, va_list ap)
 		return -1;
 	}
 
-	if ((chars = vsprintf(b, fmt, ap)) < 0)
+	if ((chars = vsnprintf(b, ((size_t)chars + 1), fmt, ap)) < 0)
 	{
 		free(b);
 	}


### PR DESCRIPTION
Struct 'json_object' forward declaration unnecessary, already declared. Please delete it.
According to standards for C Language, high Risk to  use strcat() in json_object.c . It should be replaced by strncat.
High Risk to  use vsprintf(). It should be replaced by vsnprintf.