### PR TITLE
Add support for WASI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,10 @@ include(CMakePackageConfigHelpers)
 option(BUILD_SHARED_LIBS  "Default to building shared libraries" ON)
 option(BUILD_STATIC_LIBS  "Default to building static libraries" ON)
 
+if (CMAKE_SYSTEM_NAME STREQUAL "WASI")
+    set(BUILD_SHARED_LIBS OFF)
+endif()
+
 if (BUILD_SHARED_LIBS)
     add_definitions(-D JSON_C_DLL)
 endif()
@@ -560,6 +564,7 @@ install(FILES ${JSON_C_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_FULL_INCLUDED
 
 if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING AND
    (NOT MSVC OR NOT (MSVC_VERSION LESS 1800)) # Tests need at least VS2013
+   AND NOT (CMAKE_SYSTEM_NAME STREQUAL "WASI")
    )
 add_subdirectory(tests)
 endif()

--- a/math_compat.h
+++ b/math_compat.h
@@ -13,8 +13,10 @@
 #include <float.h>
 #define isnan(x) _isnan(x)
 #else
+#ifndef __wasi__
 /* On platforms like AIX and "IBM i" we need to provide our own isnan */
 #define isnan(x) ((x) != (x))
+#endif
 #endif
 #endif
 
@@ -23,19 +25,23 @@
 #include <float.h>
 #define isinf(x) (!_finite(x))
 #else
+#ifndef __wasi__
 #include <float.h>
 /* On platforms like AIX and "IBM i" we need to provide our own isinf */
 #define isinf(x) ((x) < -DBL_MAX || (x) > DBL_MAX)
 #endif
 #endif
+#endif
 
 #ifndef HAVE_DECL_INFINITY
+#ifndef __wasi__
 #include <float.h>
 #define INFINITY (DBL_MAX + DBL_MAX)
 #define HAVE_DECL_INFINITY
 #endif
+#endif
 
-#ifndef HAVE_DECL_NAN
+#if !defined(HAVE_DECL_NAN) && !defined(__wasi__)
 #define NAN (INFINITY - INFINITY)
 #define HAVE_DECL_NAN
 #endif

--- a/snprintf_compat.h
+++ b/snprintf_compat.h
@@ -34,6 +34,27 @@ static int json_c_snprintf(char *str, size_t size, const char *format, ...)
 }
 #define snprintf json_c_snprintf
 
+#elif (defined(__wasi__))
+static int json_c_vsnprintf(char *str, size_t size, const char *format, va_list ap)
+{
+        int ret;
+        ret = vsnprintf(str, size, format, ap);
+        str[size - 1] = '\0';
+        return ret;
+}
+#define vsnprintf json_c_vsnprintf
+
+__attribute__((unused))
+static int json_c_snprintf(char *str, size_t size, const char *format, ...)
+{
+        va_list ap;
+        int ret;
+        va_start(ap, format);
+        ret = json_c_vsnprintf(str, size, format, ap);
+        va_end(ap);
+        return ret;
+}
+#define snprintf json_c_snprintf
 #elif !defined(HAVE_SNPRINTF) /* !HAVE_SNPRINTF */
 #error snprintf is required but was not found
 #endif /* !HAVE_SNPRINTF && defined(WIN32) */


### PR DESCRIPTION
Disables shared libraries for WASI only and makes sure compat doesn't redefine builtins.