### PR TITLE
CMake: remove needless policy setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,22 +5,9 @@
 #   c++11, which isn't available on e.g HPUX.
 cmake_minimum_required(VERSION 3.9)
 
-# The project() command manages VERSION variables.
-cmake_policy(SET CMP0048 NEW)
-
 # JSON-C library is C only project.
 # PROJECT_VERSION{,_MAJOR,_MINOR,_PATCH} set by project():
 project(json-c LANGUAGES C VERSION 0.17.99)
-
-# Targets may not link directly to themselves.
-cmake_policy(SET CMP0038 NEW)
-
-# MACOSX_RPATH is enabled by default.
-# We set it explicitly to avoid the warning
-cmake_policy(SET CMP0042 NEW)
-
-# Only interpret if() arguments as variables or keywords when unquoted.
-cmake_policy(SET CMP0054 NEW)
 
 # set default build type if not specified by user
 if(NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #   and many OpenWRT packages require, much newer CMake packages.
 #  We're stopping before 3.10 because that version starts requiring
 #   c++11, which isn't available on e.g HPUX.
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.9...3.12)
 
 # JSON-C library is C only project.
 # PROJECT_VERSION{,_MAJOR,_MINOR,_PATCH} set by project():
@@ -15,13 +15,6 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 set(CMAKE_C_FLAGS_RELEASE   "${CMAKE_C_FLAGS_RELEASE} -O2")
-
-# Include file check macros honor CMAKE_REQUIRED_LIBRARIES
-# i.e. the check_include_file() calls will include -lm when checking.
-# New in version 3.12.
-if(POLICY CMP0075)
-	cmake_policy(SET CMP0075 NEW)
-endif()
 
 include(CTest)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.9)
 add_executable(test1Formatted test1.c parse_flags.c parse_flags.h)
 target_compile_definitions(test1Formatted PRIVATE TEST_FORMATTED=1)
 target_link_libraries(test1Formatted PRIVATE ${PROJECT_NAME})


### PR DESCRIPTION
These policies were all introduced before CMake 3.9, so they will automatically be initialized to the new behavior when requesting a minimum version of 3.9.