### PR TITLE
Resolve build issue in tokener_parse_ex_fuzzer.c

### DIFF
--- a/fuzz/tokener_parse_ex_fuzzer.cc
+++ b/fuzz/tokener_parse_ex_fuzzer.cc
@@ -8,11 +8,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	json_tokener *tok = json_tokener_new();
 	json_object *obj = json_tokener_parse_ex(tok, data1, size);
 	
-	json_object_object_foreach(jobj, key, val) {
+	json_object_object_foreach(obj, key, val) {
 		(void)json_object_get_type(val);
 		(void)json_object_get_string(val);
 	}
-	(void)json_object_to_json_string(obj, JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED);
+	(void)json_object_to_json_string_ext(obj, JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED);
 	
 	json_object_put(obj);
 	json_tokener_free(tok);


### PR DESCRIPTION
This commit aims to resolve to 2 possible typos in variable/API names in commit 558d48a6 that causes `tokener_parse_ex_fuzzer.c` to fail to compile.