### PR TITLE
rename WIN32 to _WIN32

### DIFF
--- a/json_util.c
+++ b/json_util.c
@@ -37,13 +37,13 @@
 #include <unistd.h>
 #endif /* HAVE_UNISTD_H */
 
-#ifdef WIN32
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <io.h>
 #include <windows.h>
-#endif /* defined(WIN32) */
+#endif /* defined(_WIN32) */
 
-#if !defined(HAVE_OPEN) && defined(WIN32)
+#if !defined(HAVE_OPEN) && defined(_WIN32)
 #define open _open
 #endif
 

--- a/random_seed.c
+++ b/random_seed.c
@@ -254,7 +254,7 @@ static int get_dev_random_seed(int *seed)
 
 /* get_cryptgenrandom_seed */
 
-#ifdef WIN32
+#ifdef _WIN32
 
 #define HAVE_CRYPTGENRANDOM 1
 

--- a/snprintf_compat.h
+++ b/snprintf_compat.h
@@ -36,6 +36,6 @@ static int json_c_snprintf(char *str, size_t size, const char *format, ...)
 
 #elif !defined(HAVE_SNPRINTF) /* !HAVE_SNPRINTF */
 #error snprintf is required but was not found
-#endif /* !HAVE_SNPRINTF && defined(WIN32) */
+#endif /* !HAVE_SNPRINTF */
 
 #endif /* __snprintf_compat_h */

--- a/tests/test_util_file.c
+++ b/tests/test_util_file.c
@@ -2,11 +2,11 @@
 #undef NDEBUG
 #endif
 #include "strerror_override.h"
-#ifdef WIN32
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <io.h>
 #include <windows.h>
-#endif /* defined(WIN32) */
+#endif /* defined(_WIN32) */
 #include <fcntl.h>
 #include <limits.h>
 #include <stddef.h>

--- a/vasprintf_compat.h
+++ b/vasprintf_compat.h
@@ -8,9 +8,9 @@
 
 #include "snprintf_compat.h"
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <stdarg.h>
-#endif /* !defined(WIN32) */
+#endif /* !defined(_WIN32) */
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -18,10 +18,10 @@
 /* CAW: compliant version of vasprintf */
 static int vasprintf(char **buf, const char *fmt, va_list ap)
 {
-#ifndef WIN32
+#ifndef _WIN32
 	static char _T_emptybuffer = '\0';
 	va_list ap2;
-#endif /* !defined(WIN32) */
+#endif /* !defined(_WIN32) */
 	int chars;
 	char *b;
 
@@ -30,16 +30,16 @@ static int vasprintf(char **buf, const char *fmt, va_list ap)
 		return -1;
 	}
 
-#ifdef WIN32
+#ifdef _WIN32
 	chars = _vscprintf(fmt, ap);
-#else  /* !defined(WIN32) */
+#else  /* !defined(_WIN32) */
 	/* CAW: RAWR! We have to hope to god here that vsnprintf doesn't overwrite
 	 * our buffer like on some 64bit sun systems... but hey, it's time to move on
 	 */
 	va_copy(ap2, ap);
 	chars = vsnprintf(&_T_emptybuffer, 0, fmt, ap2);
 	va_end(ap2);
-#endif /* defined(WIN32) */
+#endif /* defined(_WIN32) */
 	if (chars < 0 || (size_t)chars + 1 > SIZE_MAX / sizeof(char))
 	{
 		return -1;


### PR DESCRIPTION
The latter is the proper macro defined by Windows headers.

Fixes compilation under at least clang-cl which mandates function declarations.

As an aside, this issue is hidden under MinGW because unistd.h there includes io.h, which defines read, write, and so forth.