### PR TITLE
random_seed.c: prefer getrandom() / /dev/{,u}random over arc4random()

### DIFF
--- a/random_seed.c
+++ b/random_seed.c
@@ -24,12 +24,6 @@
 #define HAVE_DEV_RANDOM 1
 #endif
 
-#ifdef HAVE_ARC4RANDOM
-#undef HAVE_GETRANDOM
-#undef HAVE_DEV_RANDOM
-#undef HAVE_CRYPTGENRANDOM
-#endif
-
 #if defined ENABLE_RDRAND
 
 /* cpuid */
@@ -326,10 +320,6 @@ int json_c_get_random_seed(void)
 	if (has_rdrand())
 		return get_rdrand_seed();
 #endif
-#ifdef HAVE_ARC4RANDOM
-	/* arc4random never fails, so use it if it's available */
-	return arc4random();
-#else
 #ifdef HAVE_GETRANDOM
 	{
 		int seed = 0;
@@ -351,6 +341,10 @@ int json_c_get_random_seed(void)
 			return seed;
 	}
 #endif
+#ifdef HAVE_ARC4RANDOM
+	/* arc4random never fails, so use it if it's available */
+	return arc4random();
+#else
 	return get_time_seed();
 #endif /* !HAVE_ARC4RANDOM */
 }


### PR DESCRIPTION
arc4random(3) is problematic to use during early boot, as it (as implemented by glibc or libbsd) uses getrandom(2) without the GRND_NONBLOCK flag, causing it to block until the kernel entropy pool is initialized, which may take a very long time.

One example of this is cryptsetup(8), which may be used for bringing up a LUKS encrypted root filesystem during early boot.

So instead prefer getrandom(.., GRND_NONBLOCK) (which will fail before the pool is initialized) and /dev/urandom (which will succeed, but cause the kernel to print a warning about access before the pool is initialized) before falling back to arc4random().