### PR TITLE
Add type checking for parsed objects in tokener_parse_ex_fuzzer

### DIFF
--- a/fuzz/tokener_parse_ex_fuzzer.cc
+++ b/fuzz/tokener_parse_ex_fuzzer.cc
@@ -8,9 +8,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	json_tokener *tok = json_tokener_new();
 	json_object *obj = json_tokener_parse_ex(tok, data1, size);
 	
-	json_object_object_foreach(obj, key, val) {
-		(void)json_object_get_type(val);
-		(void)json_object_get_string(val);
+	if (json_object_is_type(obj, json_type_object)) {
+		json_object_object_foreach(obj, key, val) {
+			(void)json_object_get_type(val);
+			(void)json_object_get_string(val);
+		}
 	}
 	(void)json_object_to_json_string_ext(obj, JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED);
 	


### PR DESCRIPTION
Add checking for type of parsed object in `tokener_parse_ex_fuzzer.cc` like below:

```
	if (json_object_is_type(obj, json_type_object)) {
		json_object_object_foreach(obj, key, val) {
			(void)json_object_get_type(val);
			(void)json_object_get_string(val);
		}
	}
```

I think checking the type of `obj` is `json_type_object` is enough for the`tokener_parse_ex_fuzzer.cc`.

With this change, the fuzzer(libfuzzer) will no longer terminate upon execution but will instead carry out fuzzing as expected.

For reference, the fuzzer doesn't raise a null-deref issue immediately post-execution, as shown below:
```
$ python infra/helper.py run_fuzzer json-c tokener_parse_ex_fuzzer

INFO:__main__:Running: docker run --rm --privileged --shm-size=2g --platform linux/amd64 -i -e FUZZING_ENGINE=libfuzzer -e SANITIZER=address -e RUN_FUZZER_MODE=interactive -e HELPER=True -v /home/sure/oss-fuzz/build/out/json-c-new:/out -t gcr.io/oss-fuzz-base/base-runner run_fuzzer tokener_parse_ex_fuzzer.
/out/tokener_parse_ex_fuzzer -rss_limit_mb=2560 -timeout=25 /tmp/tokener_parse_ex_fuzzer_corpus -dict=tokener_parse_ex_fuzzer.dict < /dev/null
Dictionary: 18 entries
...
#62012  NEW    cov: 498 ft: 1194 corp: 336/4132b lim: 74 exec/s: 0 rss: 58Mb L: 37/64 MS: 3 ChangeBinInt-InsertByte-InsertByte-
#62013  REDUCE cov: 498 ft: 1194 corp: 336/4131b lim: 74 exec/s: 0 rss: 58Mb L: 5/64 MS: 1 EraseBytes-
#62044  REDUCE cov: 498 ft: 1194 corp: 336/4128b lim: 74 exec/s: 0 rss: 58Mb L: 36/64 MS: 1 EraseBytes-
#62358  REDUCE cov: 498 ft: 1194 corp: 336/4127b lim: 74 exec/s: 0 rss: 58Mb L: 7/64 MS: 4 CopyPart-ChangeBinInt-EraseBytes-CopyPart-
...
```

Related to : #836 