### PR TITLE
json_pointer.c: initialize idx

### DIFF
--- a/json_pointer.c
+++ b/json_pointer.c
@@ -158,7 +158,7 @@ static int json_pointer_result_get_recursive(struct json_object *obj, char *path
                                              struct json_pointer_get_result *res)
 {
 	struct json_object *parent_obj = obj;
-	size_t idx;
+	size_t idx = 0;
 	char *endp;
 	int rc;
 


### PR DESCRIPTION
Fix the following build failure with gcc 5:

```
/home/thomas/autobuild/instance-2/output-1/build/json-c-0.17/json_pointer.c: In function 'json_pointer_result_get_recursive': /home/thomas/autobuild/instance-2/output-1/build/json-c-0.17/json_pointer.c:193:25: error: 'idx' may be used uninitialized in this function [-Werror=maybe-uninitialized]
    res->index_in_parent = idx;
                         ^
```

Fixes:
 - http://autobuild.buildroot.org/results/523b35a979d59121fe4e18c38171792b06233940/