### PR TITLE
CMP0153

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,11 +179,8 @@ endif()
 # https://github.com/ffainelli/uClibc/blob/266bdc1/libc/misc/locale/locale.c#L1322
 # So, if it looks like we're compiling for a system like that just disable
 # locale handling entirely.
-if (CMAKE_VERSION GREATER_EQUAL "3.28")
-  execute_process (COMMAND ${CMAKE_C_COMPILER} -dumpmachine ERROR_QUIET OUTPUT_VARIABLE CMAKE_GNU_C_MACHINE)
-else ()
-  exec_program(${CMAKE_C_COMPILER} ARGS -dumpmachine OUTPUT_VARIABLE CMAKE_GNU_C_MACHINE)
-endif ()
+execute_process (COMMAND ${CMAKE_C_COMPILER} -dumpmachine ERROR_QUIET OUTPUT_VARIABLE CMAKE_GNU_C_MACHINE)
+
 if (CMAKE_GNU_C_MACHINE MATCHES "uclibc")
 	message(STATUS "Detected uClibc compiler, disabling locale handling")
 	set(HAVE_SETLOCALE 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ endif()
 # So, if it looks like we're compiling for a system like that just disable
 # locale handling entirely.
 if (CMAKE_VERSION GREATER_EQUAL "3.28")
-  execute_process (COMMAND ${CMAKE_C_COMPILER} -dumpmachine OUTPUT_QUIET ERROR_QUIET ECHO_OUTPUT_VARIABLE CMAKE_GNU_C_MACHINE)
+  execute_process (COMMAND ${CMAKE_C_COMPILER} -dumpmachine ERROR_QUIET OUTPUT_VARIABLE CMAKE_GNU_C_MACHINE)
 else ()
   exec_program(${CMAKE_C_COMPILER} ARGS -dumpmachine OUTPUT_VARIABLE CMAKE_GNU_C_MACHINE)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ endif()
 # So, if it looks like we're compiling for a system like that just disable
 # locale handling entirely.
 if (CMAKE_VERSION GREATER_EQUAL "3.28")
-  execute_process (COMMAND ${CMAKE_C_COMPILER} -dumpmachine OUTPUT_QUIET ERROR_QUIET OUTPUT_VARIABLE CMAKE_GNU_C_MACHINE)
+  execute_process (COMMAND ${CMAKE_C_COMPILER} -dumpmachine OUTPUT_QUIET ERROR_QUIET ECHO_OUTPUT_VARIABLE CMAKE_GNU_C_MACHINE)
 else ()
   exec_program(${CMAKE_C_COMPILER} ARGS -dumpmachine OUTPUT_VARIABLE CMAKE_GNU_C_MACHINE)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,9 +177,13 @@ endif()
 
 # uClibc *intentionally* crashes in duplocale(), at least as of:
 # https://github.com/ffainelli/uClibc/blob/266bdc1/libc/misc/locale/locale.c#L1322
-# So, if it looks like we're compiling for a system like that just disable 
+# So, if it looks like we're compiling for a system like that just disable
 # locale handling entirely.
-exec_program(${CMAKE_C_COMPILER} ARGS -dumpmachine OUTPUT_VARIABLE CMAKE_GNU_C_MACHINE)
+if (CMAKE_VERSION GREATER_EQUAL "3.28")
+  execute_process (COMMAND ${CMAKE_C_COMPILER} -dumpmachine OUTPUT_QUIET ERROR_QUIET OUTPUT_VARIABLE CMAKE_GNU_C_MACHINE)
+else ()
+  exec_program(${CMAKE_C_COMPILER} ARGS -dumpmachine OUTPUT_VARIABLE CMAKE_GNU_C_MACHINE)
+endif ()
 if (CMAKE_GNU_C_MACHINE MATCHES "uclibc")
 	message(STATUS "Detected uClibc compiler, disabling locale handling")
 	set(HAVE_SETLOCALE 0)
@@ -569,4 +573,3 @@ if (NOT MSVC)  # cmd line apps don't built on Windows currently.
 add_subdirectory(apps)
 endif()
 endif()
-


### PR DESCRIPTION
https://cmake.org/cmake/help/latest/policy/CMP0153.html

New in version 3.28.

> 
> The [exec_program()](https://cmake.org/cmake/help/latest/command/exec_program.html#command:exec_program) command should not be called.
> 
> This command has long been superseded by the [execute_process()](https://cmake.org/cmake/help/latest/command/execute_process.html#command:execute_process) command and has been deprecated since CMake 3.0.
> 
> CMake >= 3.28 prefer that this command never be called. The OLD behavior for this policy is to allow the command to be called. The NEW behavior for this policy is to issue a FATAL_ERROR when the command is called.
> 
> This policy was introduced in CMake version 3.28. CMake version 3.28.0 warns when the policy is not set and uses OLD behavior. Use the [cmake_policy()](https://cmake.org/cmake/help/latest/command/cmake_policy.html#command:cmake_policy) command to set it to OLD or NEW explicitly.