### PR TITLE
random_seed.c: add a Coverity Scan suppression

### DIFF
--- a/random_seed.c
+++ b/random_seed.c
@@ -229,6 +229,7 @@ static int get_dev_random_seed(int *seed)
 	if ((buf.st_mode & S_IFCHR) == 0)
 		return -1;
 
+	/* coverity[toctou] */
 	int fd = open(dev_random_file, O_RDONLY);
 	if (fd < 0)
 	{


### PR DESCRIPTION
Coverity Scan warns about the use of open() after stat() being a potential TOCTOU (Time of check time of use) issue. But here there is no such issue.