### PR TITLE
json_tokener.h: json_tokener_parse_verbose: fix typo

### DIFF
--- a/json_tokener.h
+++ b/json_tokener.h
@@ -230,7 +230,7 @@ JSON_EXPORT void json_tokener_reset(struct json_tokener *tok);
 JSON_EXPORT struct json_object *json_tokener_parse(const char *str);
 
 /**
- * Parser a json_object out of the string `str`, but if it fails
+ * Parse a json_object out of the string `str`, but if it fails
  * return the error in `*error`.
  * @see json_tokener_parse()
  * @see json_tokener_parse_ex()


### PR DESCRIPTION
Before: "Parser a json_object [...]".

After: "Parse a json_object [...]".

Thanks for the library.