### PR TITLE
Handle yet another out-of-memory condition.

### DIFF
--- a/json_tokener.c
+++ b/json_tokener.c
@@ -341,6 +341,11 @@ struct json_object *json_tokener_parse_ex(struct json_tokener *tok, const char *
 #ifdef HAVE_USELOCALE
 	{
 		locale_t duploc = duplocale(oldlocale);
+		if (duploc == NULL && errno == ENOMEM)
+		{
+			tok->err = json_tokener_error_memory;
+			return NULL;
+		}
 		newloc = newlocale(LC_NUMERIC_MASK, "C", duploc);
 		if (newloc == NULL)
 		{


### PR DESCRIPTION
`duplocale()` can return NULL, with errno set to ENOMEM. In this case, bail out and set the current error code to `json_tokener_error_memory`.