### PR TITLE
fix linkhash breaking -std=c89

### DIFF
--- a/linkhash.h
+++ b/linkhash.h
@@ -334,8 +334,9 @@ int lh_table_resize(struct lh_table *t, int new_size);
 /**
  * @deprecated Don't use this outside of linkhash.h:
  */
-#if (defined(AIX_CC) || (defined(_MSC_VER) && (_MSC_VER <= 1800)) )
-/* VS2010 can't handle inline funcs, so skip it there */
+#if !defined (__STDC_VERSION__) || (__STDC_VERSION__ < 199901L)
+/* C89 compilers like VS2010 can't handle inline funcs, so skip it there,
+   note: this also applies to -std=c89 in GCC! */
 #define _LH_INLINE
 #else
 #define _LH_INLINE inline


### PR DESCRIPTION
making the definition of `_LH_INLINE` depending on `__STDC_VERSION__`, not on a specific compiler, fixing the following:

~~~
In file included from /usr/include/json-c/json.h:32,
                 from conftest.c:115:
/usr/include/json-c/linkhash.h:332:19: error: expected ';' before 'unsigned'
  332 | static _LH_INLINE unsigned long lh_get_hash(const struct lh_table *t, const void *k)
      |                   ^~~~~~~~
~~~