### PR TITLE
Correct year in changelog for 0.18 release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,7 +13,7 @@ Significant changes and bug fixes
 ---------------------------------
 * none yet
 
-0.18 (up to commit 6bfab90, 2023-09-15)
+0.18 (up to commit 6bfab90, 2024-09-15)
 ========================================
 
 Deprecated and removed features:


### PR DESCRIPTION
The change log's year timestamp for the 0.18 release is a typo and confused me for a moment looking it over. This PR fixes that.