### PR TITLE
Fix underline bug in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ You can download and install JSON-C using the [vcpkg](https://github.com/Microso
 
 The JSON-C port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
-<a name="android">
+<a name="android"></a>
 Building for Android
 ----------------------
 
@@ -270,7 +270,7 @@ cmake \
 make install
 ```
 
-<a name="linking">
+<a name="linking"></a>
 Linking to `libjson-c`
 ----------------------
 
@@ -308,7 +308,7 @@ cd build
 cmake -DCMAKE_PREFIX_PATH=/path/to/json_c/install/lib64/cmake ..
 ```
 
-<a name="using">
+<a name="using"></a>
 Using json-c
 ------------
 


### PR DESCRIPTION
Under the "Usage"-section some text is erroneously underlined, because some `a`-tags aren't closed. All this pull-request does is close them.