### PR TITLE
Handle NULL gracefully in json_tokener_free

### DIFF
--- a/json_tokener.c
+++ b/json_tokener.c
@@ -182,6 +182,8 @@ struct json_tokener *json_tokener_new(void)
 
 void json_tokener_free(struct json_tokener *tok)
 {
+	if (!tok)
+		return;
 	json_tokener_reset(tok);
 	if (tok->pb)
 		printbuf_free(tok->pb);


### PR DESCRIPTION
Similarly to glibc's free, make json_tokener_free(NULL) a no-op, to simplify cleanup paths.