### PR TITLE
random_seed.c: get_getrandom_seed(): use GRND_INSECURE if available

### DIFF
--- a/random_seed.c
+++ b/random_seed.c
@@ -176,6 +176,12 @@ retry:
 #include <sys/random.h>
 #endif
 
+/* Return best effort random data even if random pool is not yet
+ * initialized. Available since Linux 5.6 */
+#ifndef GRND_INSECURE
+#define GRND_INSECURE 0
+#endif
+
 static int get_getrandom_seed(int *seed)
 {
 	DEBUG_SEED("get_getrandom_seed");
@@ -184,7 +190,7 @@ static int get_getrandom_seed(int *seed)
 
 	do
 	{
-		ret = getrandom(seed, sizeof(*seed), GRND_NONBLOCK);
+		ret = getrandom(seed, sizeof(*seed), GRND_NONBLOCK | GRND_INSECURE);
 	} while ((ret == -1) && (errno == EINTR));
 
 	if (ret == -1)


### PR DESCRIPTION
As explained in https://github.com/json-c/json-c/pull/832, getrandom(.., GRND_NONBLOCK) fails with EAGAIN if the Linux kernel random number pool is not yet initialized.

The use case here is initializing the hash table seed rather than strong randomness for crypto, so use GRND_INSECURE if available (Linux 5.6+) to make getrandom() return best effort random data during bootup rather than fail.