### PR TITLE
Fix bug involving supplemental code points that look like high surrogates

### DIFF
--- a/json_tokener.c
+++ b/json_tokener.c
@@ -145,8 +145,8 @@ enum json_tokener_error json_tokener_get_error(struct json_tokener *tok)
 }
 
 /* Stuff for decoding unicode sequences */
-#define IS_HIGH_SURROGATE(uc) (((uc)&0xFC00) == 0xD800)
-#define IS_LOW_SURROGATE(uc) (((uc)&0xFC00) == 0xDC00)
+#define IS_HIGH_SURROGATE(uc) (((uc)&0xFFFFFC00) == 0xD800)
+#define IS_LOW_SURROGATE(uc) (((uc)&0xFFFFFC00) == 0xDC00)
 #define DECODE_SURROGATE_PAIR(hi, lo) ((((hi)&0x3FF) << 10) + ((lo)&0x3FF) + 0x10000)
 static unsigned char utf8_replacement_char[3] = {0xEF, 0xBF, 0xBD};
 

--- a/tests/test_parse.c
+++ b/tests/test_parse.c
@@ -113,6 +113,9 @@ static void test_basic_parse(void)
 	single_basic_parse("\"\\udd27\"", 0);
 	// Test with a "short" high surrogate
 	single_basic_parse("[9,'\\uDAD", 0);
+	single_basic_parse("\"[9,'\\uDAD\"", 0);
+	// Test with a supplemental character that looks like a high surrogate
+	single_basic_parse("\"\\uD836\\uDE87\"", 0);
 	single_basic_parse("null", 0);
 	single_basic_parse("NaN", 0);
 	single_basic_parse("-NaN", 0); /* non-sensical, returns null */
@@ -331,6 +334,11 @@ struct incremental_step
     /* Check that json_tokener_reset actually resets */
     {"{ \"foo", -1, -1, json_tokener_continue, 1, 0},
     {": \"bar\"}", -1, 0, json_tokener_error_parse_unexpected, 1, 0},
+
+    /* Check a supplemental code point that looks like a high surrogate */
+    {"\"\\uD836", -1, -1, json_tokener_continue, 0, 0},
+    {"\\uDE87", -1, -1, json_tokener_continue, 0, 0},
+    {"\"", -1, -1, json_tokener_success, 1, 0},
 
     /* Check incremental parsing with trailing characters */
     {"{ \"foo", -1, -1, json_tokener_continue, 0, 0},

--- a/tests/test_parse.expected
+++ b/tests/test_parse.expected
@@ -14,7 +14,7 @@ new_obj.to_string("\ud840")="�"
 new_obj.to_string("\udd27")="�"
 new_obj.to_string([9,'\uDAD)=null
 new_obj.to_string("[9,'\uDAD")=null
-new_obj.to_string("\uD836\uDE87")="�"
+new_obj.to_string("\uD836\uDE87")="𝪇"
 new_obj.to_string(null)=null
 new_obj.to_string(NaN)=NaN
 new_obj.to_string(-NaN)=null
@@ -142,7 +142,7 @@ json_tokener_parse_ex(tok, { "foo      ,   6) ... OK: got correct error: continu
 json_tokener_parse_ex(tok, : "bar"}    ,   8) ... OK: got correct error: unexpected character
 json_tokener_parse_ex(tok, "\uD836     ,   7) ... OK: got correct error: continue
 json_tokener_parse_ex(tok, \uDE87      ,   6) ... OK: got correct error: continue
-json_tokener_parse_ex(tok, "           ,   1) ... OK: got object of type [string]: "�"
+json_tokener_parse_ex(tok, "           ,   1) ... OK: got object of type [string]: "𝪇"
 json_tokener_parse_ex(tok, { "foo      ,   6) ... OK: got correct error: continue
 json_tokener_parse_ex(tok, ": {"bar    ,   8) ... OK: got correct error: continue
 json_tokener_parse_ex(tok, ":13}}XXXX  ,  10) ... OK: got object of type [object]: { "foo": { "bar": 13 } }

--- a/tests/test_parse.expected
+++ b/tests/test_parse.expected
@@ -13,6 +13,8 @@ new_obj.to_string("\ud840\u4e16")="�世"
 new_obj.to_string("\ud840")="�"
 new_obj.to_string("\udd27")="�"
 new_obj.to_string([9,'\uDAD)=null
+new_obj.to_string("[9,'\uDAD")=null
+new_obj.to_string("\uD836\uDE87")="�"
 new_obj.to_string(null)=null
 new_obj.to_string(NaN)=NaN
 new_obj.to_string(-NaN)=null
@@ -138,6 +140,9 @@ json_tokener_parse_ex(tok, "ä"        ,   4) ... OK: got object of type [string
 json_tokener_parse_ex(tok, "ä"        ,   4) ... OK: got object of type [string]: "ä"
 json_tokener_parse_ex(tok, { "foo      ,   6) ... OK: got correct error: continue
 json_tokener_parse_ex(tok, : "bar"}    ,   8) ... OK: got correct error: unexpected character
+json_tokener_parse_ex(tok, "\uD836     ,   7) ... OK: got correct error: continue
+json_tokener_parse_ex(tok, \uDE87      ,   6) ... OK: got correct error: continue
+json_tokener_parse_ex(tok, "           ,   1) ... OK: got object of type [string]: "�"
 json_tokener_parse_ex(tok, { "foo      ,   6) ... OK: got correct error: continue
 json_tokener_parse_ex(tok, ": {"bar    ,   8) ... OK: got correct error: continue
 json_tokener_parse_ex(tok, ":13}}XXXX  ,  10) ... OK: got object of type [object]: { "foo": { "bar": 13 } }
@@ -363,5 +368,5 @@ json_tokener_parse_ex(tok, {"":1}     ,   7) ... OK: got correct error: invalid
 json_tokener_parse_ex(tok, {"":1}     ,   7) ... OK: got correct error: invalid string sequence
 json_tokener_parse_ex(tok, {"":1}     ,   7) ... OK: got correct error: invalid string sequence
 json_tokener_parse_ex(tok, {"":1}     ,   7) ... OK: got correct error: invalid string sequence
-End Incremental Tests OK=269 ERROR=0
+End Incremental Tests OK=272 ERROR=0
 ==================================


### PR DESCRIPTION
Hi there! I came across a bug when running Unicode conformance tests on a platform that uses `json-c` and eventually traced it to here.

In the main parse loop, the code reads a surrogate pair encoded as `\uXXXX\uYYYY`, and then it decodes it as follows:

```c
					tok->ucs_char = DECODE_SURROGATE_PAIR(tok->high_surrogate,
					                                      tok->ucs_char);
```

This is fine so far. But then back in the main loop:

```c
			if (tok->ucs_char < 0x80)
			{
				// handle 1-byte character
			}
			else if (tok->ucs_char < 0x800)
			{
				// handle 2-byte character
			}
			else if (IS_HIGH_SURROGATE(tok->ucs_char))
			{
				// handle high surrogate
			}
			else if (IS_LOW_SURROGATE(tok->ucs_char))
			{
				// handle unpaired low surrogate
			}
			else if (tok->ucs_char < 0x10000)
			{
				// handle 3-byte character
			}
			else if (tok->ucs_char < 0x110000)
			{
				// handle 4-byte character
			}
			else
			{
				// unknown error
			}
```

At this point in the parse, we should be hitting the `if (tok->ucs_char < 0x110000)` case, and most of the time we do. However, for some supplemental code points, we are hitting the `if (IS_HIGH_SURROGATE(tok->ucs_char))` case. The definition of `IS_HIGH_SURROGATE` is:

```c
#define IS_HIGH_SURROGATE(uc) (((uc)&0xFC00) == 0xD800)
```

This correctly identifies BMP code points that are high surrogates. However, characters in multiple supplemental blocks also pass this test, including [SignWriting](https://en.wikipedia.org/wiki/Sutton_SignWriting_(Unicode_block)) (code points in range U+1D800..U+1DBFF) and [CJK Unified Ideographs Extension F](https://en.wikipedia.org/wiki/CJK_Unified_Ideographs_Extension_F) (code points in range U+2D800..U+2DBFF), and also various private-use ranges.

To fix this, I changed the macro to mask all bits in the 32-bit integer, instead of just the bottom 16 bits of the 32-bit integer.

CC @sven-oly @echeran