### PR TITLE
CMake: sync minimum version

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8)  # see ../CMakeLists.txt for why 2.8
+cmake_minimum_required(VERSION 3.9...3.12)  # see ../CMakeLists.txt for why
 
 if(POLICY CMP0075)
     cmake_policy(SET CMP0075 NEW)


### PR DESCRIPTION
To fix build with CMake 4.1.0:

```
Compatibility with CMake < 3.5 has been removed from CMake.

Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
to tell CMake that the project requires at least <min> but has been updated
to work with policies introduced by <max> or earlier.

Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```