### PR TITLE
Include getopt.h header file if the platform is not AIX.

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -94,6 +94,9 @@ endif() # end "standalone mode" block
 
 # ---------------------------------
 
+# Check whether getopt.h exists
+check_include_file(getopt.h HAVE_GETOPT_H)
+
 check_include_file(sys/resource.h   HAVE_SYS_RESOURCE_H) # for getrusage
 if (HAVE_SYS_RESOURCE_H)
     check_symbol_exists(getrusage   "sys/resource.h" HAVE_GETRUSAGE)

--- a/apps/json_parse.c
+++ b/apps/json_parse.c
@@ -1,7 +1,9 @@
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
+#ifdef HAVE_GETOPT_H 
 #include <getopt.h>
+#endif
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Hi All,

In the current code (json_parse.c), we include <getopt.h> to use the getopt() function:

`#include <getopt.h>`

This works on most platforms, but AIX does not provide a getopt.h header, causing below build failures:

```
/home/buildusr/rpmbuild/BUILD/json-c-0.18/64bit/apps/json_parse.c:4:10: fatal error: getopt.h: No such file or directory
    4 | #include <getopt.h>
      |          ^~~~~~~~~~
compilation terminated.
gmake[2]: *** [apps/CMakeFiles/json_parse.dir/build.make:79: apps/CMakeFiles/json_parse.dir/json_parse.c.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:2119: apps/CMakeFiles/json_parse.dir/all] Error 2
gmake: *** [Makefile:166: all] Error 2
```

However, AIX does have an implementation of getopt() in another location, so including getopt.h is not necessary on AIX.

Change proposed in this PR:

- Include getopt.h only if the platform is not AIX.
- Use a preprocessor check for AIX to conditionally include the header:

```
#ifndef _AIX
#include <getopt.h>
#endif
```