### PR TITLE
Support MSVC in packages that use GNU Autoconf.

### DIFF
--- a/json_inttypes.h
+++ b/json_inttypes.h
@@ -29,7 +29,7 @@ typedef unsigned __int64 uint64_t;
 
 #endif
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(ssize_t)
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
 #endif

--- a/json_object_private.h
+++ b/json_object_private.h
@@ -28,7 +28,7 @@ struct json_object;
 #include <unistd.h>
 #endif /* HAVE_UNISTD_H */
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(ssize_t)
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
 #endif


### PR DESCRIPTION
Fixes https://github.com/json-c/json-c/issues/909

When ssize_t is defined as a macro, typically through a package's config.h file, the installed json*.h files must not attempt to define ssize_t via typedef.