### PR TITLE
Fix: OOM vulnerability cause by is_valid_index

### DIFF
--- a/json-c.sym
+++ b/json-c.sym
@@ -182,5 +182,8 @@ JSONC_0.18 {
 } JSONC_0.17;
 
 JSONC_0.19 {
-#  global:
+  global:
+    json_pointer_set_with_limit_index;
+    json_pointer_set_with_cb;
+    json_object_array_put_with_idx_limit_cb;
 } JSONC_0.18;

--- a/json_pointer.c
+++ b/json_pointer.c
@@ -79,16 +79,6 @@ static int is_valid_index(const char *path, size_t *idx)
 	// but ULLONG_MAX will be longer than any array length so that's ok.
 	*idx = strtoull(path, NULL, 10);
 
-	// Check against a maximum to prevent excessive memory allocations.
-	// An extremely large index, even if it doesn't overflow size_t,
-	// will cause a huge memory allocation request via realloc,
-	// leading to an OOM.
-	if (*idx > JSON_C_POINTER_MAX_ARRAY_IDX)
-	{
-    	errno = EINVAL;
-    	return 0;
-	}
-
 	return 1;
 }
 

--- a/json_pointer.c
+++ b/json_pointer.c
@@ -79,6 +79,16 @@ static int is_valid_index(const char *path, size_t *idx)
 	// but ULLONG_MAX will be longer than any array length so that's ok.
 	*idx = strtoull(path, NULL, 10);
 
+	// Check against a maximum to prevent excessive memory allocations.
+	// An extremely large index, even if it doesn't overflow size_t,
+	// will cause a huge memory allocation request via realloc,
+	// leading to an OOM.
+	if (*idx > JSON_C_POINTER_MAX_ARRAY_IDX)
+	{
+    	errno = EINVAL;
+    	return 0;
+	}
+
 	return 1;
 }
 

--- a/json_pointer.c
+++ b/json_pointer.c
@@ -430,13 +430,14 @@ int json_pointer_set_with_limit_index(struct json_object **obj, const char *path
 int json_object_array_put_idx_with_limit_cb(struct json_object *jso, size_t idx,
                                        struct json_object *jso_new, void *priv)
 {
+	size_t max_idx;
     // use priv as a size_t pointer to pass in the maximum allowed index
 	if (!priv)
 	{
 		errno = EINVAL;
 		return -1;
 	}
-    size_t max_idx = *(size_t*)priv;
+    max_idx = *(size_t*)priv;
 
     // Check against a maximum to prevent excessive memory allocations.
 	// An extremely large index, even if it doesn't overflow size_t,

--- a/json_pointer.c
+++ b/json_pointer.c
@@ -120,15 +120,9 @@ static int json_pointer_get_single_path(struct json_object *obj, char *path,
 	return 0;
 }
 
-static int json_object_array_put_idx_cb(struct json_object *parent, size_t idx,
-					struct json_object *value, void *priv)
-{
-	return json_object_array_put_idx(parent, idx, value);
-}
-
 static int json_pointer_set_single_path(struct json_object *parent, const char *path,
                                         struct json_object *value,
-					json_pointer_array_set_cb array_set_cb, void *priv)
+					json_pointer_set_cb set_cb, int cb_handles_obj, void *priv)
 {
 	if (json_object_is_type(parent, json_type_array))
 	{
@@ -138,14 +132,23 @@ static int json_pointer_set_single_path(struct json_object *parent, const char *
 			return json_object_array_add(parent, value);
 		if (!is_valid_index(path, &idx))
 			return -1;
-		return array_set_cb(parent, idx, value, priv);
+		return set_cb(parent, NULL, idx, value, priv);
 	}
 
 	/* path replacements should have been done in json_pointer_get_single_path(),
 	 * and we should still be good here
 	 */
 	if (json_object_is_type(parent, json_type_object))
-		return json_object_object_add(parent, path, value);
+	{
+		if (cb_handles_obj)
+		{
+			return set_cb(parent, path, (size_t)-1, value, priv);
+		}
+		else
+		{
+			return json_object_object_add(parent, path, value);
+		}
+	}
 
 	/* Getting here means that we tried to "dereference" a primitive JSON type
 	 * (like string, int, bool).i.e. add a sub-object to it
@@ -298,9 +301,9 @@ out:
 	return rc;
 }
 
-int json_pointer_set_with_array_cb(struct json_object **obj, const char *path,
+int json_pointer_set_with_cb(struct json_object **obj, const char *path,
 				   struct json_object *value,
-				   json_pointer_array_set_cb array_set_cb, void *priv)
+				   json_pointer_set_cb set_cb, int cb_handles_obj, void *priv)
 {
 	const char *endp;
 	char *path_copy = NULL;
@@ -330,7 +333,7 @@ int json_pointer_set_with_array_cb(struct json_object **obj, const char *path,
 	if ((endp = strrchr(path, '/')) == path)
 	{
 		path++;
-		return json_pointer_set_single_path(*obj, path, value, array_set_cb, priv);
+		return json_pointer_set_single_path(*obj, path, value, set_cb, cb_handles_obj, priv);
 	}
 
 	/* pass a working copy to the recursive call */
@@ -347,12 +350,21 @@ int json_pointer_set_with_array_cb(struct json_object **obj, const char *path,
 		return rc;
 
 	endp++;
-	return json_pointer_set_single_path(set, endp, value, array_set_cb, priv);
+	return json_pointer_set_single_path(set, endp, value, set_cb, cb_handles_obj, priv);
+}
+
+static int default_put_cb(struct json_object *parent, const char *key, size_t idx,
+                          struct json_object *value, void *priv)
+{
+    if (key == NULL)
+        return json_object_array_put_idx(parent, idx, value);
+    else
+        return json_object_object_add(parent, key, value);
 }
 
 int json_pointer_set(struct json_object **obj, const char *path, struct json_object *value)
 {
-	return json_pointer_set_with_array_cb(obj, path, value, json_object_array_put_idx_cb, NULL);
+	return json_pointer_set_with_cb(obj, path, value, default_put_cb, 1, NULL);
 }
 
 int json_pointer_setf(struct json_object **obj, struct json_object *value, const char *path_fmt,
@@ -407,8 +419,7 @@ int json_pointer_setf(struct json_object **obj, struct json_object *value, const
 
 set_single_path:
 	endp++;
-	rc = json_pointer_set_single_path(set, endp, value,
-					  json_object_array_put_idx_cb, NULL);
+	rc = json_pointer_set_single_path(set, endp, value, default_put_cb, 1, NULL);
 out:
 	free(path_copy);
 	return rc;
@@ -420,33 +431,45 @@ int json_pointer_set_with_limit_index(struct json_object **obj, const char *path
 	// -1 means no limits
     if (limit_index == (size_t)-1)
     {
-        return json_pointer_set_with_array_cb(obj, path, value, json_object_array_put_idx_cb, NULL);
+        return json_pointer_set_with_cb(obj, path, value, default_put_cb, 1, NULL);
     }
-    return json_pointer_set_with_array_cb(obj, path, value,
-                      json_object_array_put_idx_with_limit_cb, &limit_index);
+    return json_pointer_set_with_cb(obj, path, value,
+                      json_object_array_put_with_idx_limit_cb, 0, &limit_index);
 }
 
 /* safe callback for array index limit */
-int json_object_array_put_idx_with_limit_cb(struct json_object *jso, size_t idx,
-                                       struct json_object *jso_new, void *priv)
+int json_object_array_put_with_idx_limit_cb(struct json_object *jso, const char *key, size_t idx,
+                                    		struct json_object *jso_new, void *priv)
 {
 	size_t max_idx;
-    // use priv as a size_t pointer to pass in the maximum allowed index
-	if (!priv)
-	{
-		errno = EINVAL;
-		return -1;
-	}
-    max_idx = *(size_t*)priv;
 
-    // Check against a maximum to prevent excessive memory allocations.
-	// An extremely large index, even if it doesn't overflow size_t,
-	// will cause a huge memory allocation request via realloc,
-	// leading to an OOM.
-	if (idx > max_idx)
-    {
-        errno = EINVAL;
-        return -1;
-    }
-    return json_object_array_put_idx(jso, idx, jso_new);
+	if (key == NULL)
+	{
+		// array operation
+    	// use priv as a size_t pointer to pass in the maximum allowed index.
+		// The priv is required context for this callback and must not be NULL.
+		if (!priv)
+		{
+			errno = EFAULT;
+			return -1;
+		}
+
+    	max_idx = *(size_t*)priv;
+
+    	// Check against a maximum to prevent excessive memory allocations.
+		// An extremely large index, even if it doesn't overflow size_t,
+		// will cause a huge memory allocation request via realloc,
+		// leading to an OOM.
+		if (idx > max_idx)
+    	{
+        	errno = EINVAL;
+        	return -1;
+    	}
+    	return json_object_array_put_idx(jso, idx, jso_new);
+	}
+	else
+	{
+		// object operation
+        return json_object_object_add(jso, key, jso_new);
+	}
 }

--- a/json_pointer.h
+++ b/json_pointer.h
@@ -133,9 +133,14 @@ JSON_EXPORT int json_pointer_set_with_limit_index(struct json_object **obj, cons
 
 /**
  * Callback function type.
+ * 
+ * When setting an array element, 'key' will be NULL and 'idx' will be the
+ * target index.
+ * When setting an object field, 'key' will be the target key and 'idx' will
+ * be -1.
  */
-typedef int(*json_pointer_array_set_cb)(json_object *parent, size_t idx,
-                                        json_object *value, void *priv);
+typedef int(*json_pointer_set_cb)(json_object *parent, const char *key, size_t idx,
+                                    json_object *value, void *priv);
 
 /**
  * Variant of 'json_pointer_set()' that allows specifying a custom callback
@@ -143,26 +148,29 @@ typedef int(*json_pointer_array_set_cb)(json_object *parent, size_t idx,
  * @param obj the json_object instance/tree to which to add a sub-object
  * @param path a (RFC6901) string notation for the sub-object to set in the tree
  * @param value object to set at path
- * @param array_set_cb A custom callback function to handle setting the element
- *                     within an array
- * @param priv A private pointer passed through to the array_set_cb callback,
+ * @param set_cb A custom callback function to handle setting the element
+ * @param cb_handles_obj If 0, the callback is only invoked for array modifications.
+ *                       If 1, the callback is invoked for both array and object
+ *                       modifications.
+ * @param priv A private pointer passed through to the set_cb callback,
  *             for user-defined context
  *
  * @return negative if an error (or not found), or 0 if succeeded
  */
-JSON_EXPORT int json_pointer_set_with_array_cb(struct json_object **obj, const char *path,
+JSON_EXPORT int json_pointer_set_with_cb(struct json_object **obj, const char *path,
                                    struct json_object *value,
-                                   json_pointer_array_set_cb array_set_cb, void *priv);
+                                   json_pointer_set_cb set_cb, int cb_handles_obj, void *priv);
 
 /**
- * A secure callback for 'json_pointer_set_with_array_cb()' that enforces a
+ * A safer callback for 'json_pointer_set_with_cb()' that enforces a
  * maximum array index.
  *
- * This function can be used as the 'array_set_cb' argument to prevent OOM.
+ * This function can be used as the 'set_cb' argument to prevent OOM.
  * It expects the 'priv' argument to be a valid pointer to a 'size_t' variable
  * that holds the maximum allowed index.
  *
  * @param jso the parent json_object array.
+ * @param key the object field where the element is to be placed, should be NULL here.
  * @param idx the index where the element is to be placed.
  * @param jso_new the new json_object to place at the index.
  * @param priv A pointer to a 'size_t' variable specifying the maximum index.
@@ -170,7 +178,7 @@ JSON_EXPORT int json_pointer_set_with_array_cb(struct json_object **obj, const c
  *
  * @return 0 on success, or a negative value if idx exceeds the limit or 'priv' is NULL.
  */
-JSON_EXPORT int json_object_array_put_idx_with_limit_cb(struct json_object *jso, size_t idx,
+JSON_EXPORT int json_object_array_put_with_idx_limit_cb(struct json_object *jso, const char *key, size_t idx,
                                                    struct json_object *jso_new, void *priv);
 
 #ifdef __cplusplus

--- a/json_pointer.h
+++ b/json_pointer.h
@@ -21,6 +21,14 @@ extern "C" {
 #endif
 
 /**
+ * Maximum array index for JSON Pointer, preventing excessive memory allocations.
+ * The default value is 10,000,000.
+ */
+#ifndef JSON_C_POINTER_MAX_ARRAY_IDX
+#define JSON_C_POINTER_MAX_ARRAY_IDX 10000000
+#endif
+
+/**
  * Retrieves a JSON sub-object from inside another JSON object
  * using the JSON pointer notation as defined in RFC 6901
  *   https://tools.ietf.org/html/rfc6901

--- a/json_pointer_private.h
+++ b/json_pointer_private.h
@@ -29,12 +29,19 @@ struct json_pointer_get_result {
 int json_pointer_get_internal(struct json_object *obj, const char *path,
                               struct json_pointer_get_result *res);
 
-typedef int(*json_pointer_array_set_cb)(json_object *parent, size_t idx,
-                                        json_object *value, void *priv);
+// replaced by json_pointer_set_cb
+// typedef int(*json_pointer_array_set_cb)(json_object *parent, size_t idx,
+//                                         json_object *value, void *priv);
+typedef int(*json_pointer_set_cb)(json_object *parent, const char *key, size_t idx,
+                                    json_object *value, void *priv);
 
-int json_pointer_set_with_array_cb(struct json_object **obj, const char *path,
+// replaced by json_pointer_set_with_cb
+// int json_pointer_set_with_array_cb(struct json_object **obj, const char *path,
+//                                    struct json_object *value,
+//                                    json_pointer_array_set_cb array_set_cb, void *priv);
+int json_pointer_set_with_cb(struct json_object **obj, const char *path,
                                    struct json_object *value,
-                                   json_pointer_array_set_cb array_set_cb, void *priv);
+                                   json_pointer_set_cb set_cb, int cb_handles_obj, void *priv);
 
 #ifdef __cplusplus
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ set(ALL_TEST_NAMES
 
 if (NOT DISABLE_JSON_POINTER)
     set(ALL_TEST_NAMES ${ALL_TEST_NAMES} test_json_pointer)
+    set(ALL_TEST_NAMES ${ALL_TEST_NAMES} test_safe_json_pointer_set)
     if (NOT DISABLE_JSON_PATCH)
         set(ALL_TEST_NAMES ${ALL_TEST_NAMES} test_json_patch)
     endif()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -27,6 +27,7 @@ test_cases = [
   ['test_visit', 'test_visit.expected'],
   ['test_object_iterator', 'test_object_iterator.expected'],
   ['test_json_pointer', 'test_json_pointer.expected'],
+  ['test_safe_json_pointer_set', 'test_safe_json_pointer_set.expected'],
   ['test_json_patch', 'test_json_patch.expected'],
 ]
 

--- a/tests/test_safe_json_pointer_set.c
+++ b/tests/test_safe_json_pointer_set.c
@@ -1,0 +1,242 @@
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "json.h"
+
+static const char *input_json_str = "{ "
+                                    "'foo': ['bar', 'baz'], "
+                                    "'': 0, "
+                                    "'a/b': 1, "
+                                    "'c%d': 2, "
+                                    "'e^f': 3, "
+                                    "'g|h': 4, "
+                                    "'i\\\\j': 5, "
+                                    "'k\\\"l': 6, "
+                                    "' ': 7, "
+                                    "'m~n': 8 "
+                                    "}";
+
+static void test_example_set_with_limit_index(void)
+{
+    struct json_object *jo2, *jo1 = json_tokener_parse(input_json_str);
+    size_t limit_index = 10;
+
+    // testing if json_pointer_set_with_limit_index() works as json_pointer_set()
+    assert(jo1 != NULL);
+	printf("PASSED - SET_WITH_LIMIT - LOADED TEST JSON\n");
+	printf("%s\n", json_object_get_string(jo1));
+
+    assert(0 == json_pointer_set_with_limit_index(&jo1, "/foo/1", json_object_new_string("cod"), limit_index));
+	assert(0 == strcmp("cod", json_object_get_string(json_object_array_get_idx(
+	                              json_object_object_get(jo1, "foo"), 1))));
+	printf("PASSED - SET_WITH_LIMIT - 'cod' in /foo/1\n");
+	assert(0 != json_pointer_set_with_limit_index(&jo1, "/fud/gaw", (jo2 = json_tokener_parse("[1,2,3]")), limit_index));
+	assert(errno == ENOENT);
+	printf("PASSED - SET_WITH_LIMIT - non-existing /fud/gaw\n");
+	assert(0 == json_pointer_set_with_limit_index(&jo1, "/fud", json_object_new_object(), limit_index));
+	printf("PASSED - SET_WITH_LIMIT - /fud == {}\n");
+	assert(0 == json_pointer_set_with_limit_index(&jo1, "/fud/gaw", jo2, limit_index)); /* re-using jo2 from above */
+	printf("PASSED - SET_WITH_LIMIT - /fug/gaw == [1,2,3]\n");
+	assert(0 == json_pointer_set_with_limit_index(&jo1, "/fud/gaw/0", json_object_new_int(0), limit_index));
+	assert(0 == json_pointer_setf(&jo1, json_object_new_int(0), "%s%s/%d", "/fud", "/gaw", 0));
+	printf("PASSED - SET_WITH_LIMIT - /fug/gaw == [0,2,3]\n");
+	assert(0 == json_pointer_set_with_limit_index(&jo1, "/fud/gaw/-", json_object_new_int(4), limit_index));
+	printf("PASSED - SET_WITH_LIMIT - /fug/gaw == [0,2,3,4]\n");
+	assert(0 == json_pointer_set_with_limit_index(&jo1, "/", json_object_new_int(9), limit_index));
+	printf("PASSED - SET_WITH_LIMIT - / == 9\n");
+
+	jo2 = json_tokener_parse(
+	    "{ 'foo': [ 'bar', 'cod' ], '': 9, 'a/b': 1, 'c%d': 2, 'e^f': 3, 'g|h': 4, 'i\\\\j': "
+	    "5, 'k\\\"l': 6, ' ': 7, 'm~n': 8, 'fud': { 'gaw': [ 0, 2, 3, 4 ] } }");
+	assert(json_object_equal(jo2, jo1));
+	printf("PASSED - SET_WITH_LIMIT - Final JSON is: %s\n", json_object_get_string(jo1));
+	json_object_put(jo2);
+
+	assert(0 == json_pointer_set_with_limit_index(&jo1, "", json_object_new_int(10), limit_index));
+	assert(10 == json_object_get_int(jo1));
+	printf("%s\n", json_object_get_string(jo1));
+
+	json_object_put(jo1);
+
+	jo1 = json_tokener_parse("[0, 1, 2, 3]");
+	jo2 = json_tokener_parse("[0, 1, 2, 3, null, null, null, 7]");
+
+	assert(0 == json_pointer_set_with_limit_index(&jo1, "/7", json_object_new_int(7), limit_index));
+	assert(1 == json_object_equal(jo1, jo2));
+
+	json_object_put(jo1);
+
+	jo1 = json_tokener_parse("[0, 1, 2, 3]");
+
+	assert(0 == json_pointer_setf(&jo1, json_object_new_int(7), "/%u", 7));
+	assert(1 == json_object_equal(jo1, jo2));
+
+	json_object_put(jo1);
+	json_object_put(jo2);
+
+    // testing with limit_index
+    jo1 = json_tokener_parse("{'foo': ['bar', 'baz']}");
+    jo2 = json_tokener_parse("{'foo': ['bar', 'cod']}");
+
+    assert(0 == json_pointer_set_with_limit_index(&jo1, "/foo/1", json_object_new_string("cod"), limit_index));
+    assert(json_object_equal(jo1, jo2));
+    printf("PASSED - SET_LIMIT - Set value within limit (/foo/1 with limit 10)\n");
+
+    assert(0 == json_pointer_set_with_limit_index(&jo1, "/bar", json_object_new_string("new_field"), limit_index));
+    printf("PASSED - SET_LIMIT - Set value on an object (limit is ignored)\n");
+
+    assert(0 == json_pointer_set_with_limit_index(&jo1, "/foo/20", json_object_new_string("big_index"), (size_t)-1));
+    printf("PASSED - SET_LIMIT - Set value with limit_index = -1 (no limit)\n");
+
+    json_object_put(jo1);
+    json_object_put(jo2);
+}
+
+static void test_wrong_inputs_set_with_limit_index(void)
+{
+    struct json_object *jo2, *jo1 = json_tokener_parse(input_json_str);
+    size_t limit_index = 10;
+
+    // testing if json_pointer_set_with_limit_index() works as json_pointer_set()
+    assert(jo1 != NULL);
+	printf("PASSED - SET_WITH_LIMIT - LOADED TEST JSON\n");
+	printf("%s\n", json_object_get_string(jo1));
+
+	assert(0 != json_pointer_set_with_limit_index(NULL, NULL, NULL, limit_index));
+	assert(0 != json_pointer_set_with_limit_index(&jo1, NULL, NULL, limit_index));
+	printf("PASSED - SET_WITH_LIMIT - failed with NULL params for input json & path\n");
+
+	assert(0 != json_pointer_set_with_limit_index(&jo1, "foo/bar", (jo2 = json_object_new_string("cod")), limit_index));
+	printf("PASSED - SET_WITH_LIMIT - failed 'cod' with path 'foo/bar'\n");
+	json_object_put(jo2);
+
+	// assert(0 !=
+	//        json_pointer_setf(&jo1, (jo2 = json_object_new_string("cod")), "%s", "foo/bar"));
+	// printf("PASSED - SET_WITH_LIMIT - failed 'cod' with path 'foo/bar'\n");
+	// json_object_put(jo2);
+
+	assert(0 != json_pointer_set_with_limit_index(&jo1, "0", (jo2 = json_object_new_string("cod")), limit_index));
+	printf("PASSED - SET_WITH_LIMIT - failed with invalid array index'\n");
+	json_object_put(jo2);
+
+	jo2 = json_object_new_string("whatever");
+	assert(0 != json_pointer_set_with_limit_index(&jo1, "/fud/gaw", jo2, limit_index));
+	assert(0 == json_pointer_set_with_limit_index(&jo1, "/fud", json_object_new_object(), limit_index));
+	assert(0 == json_pointer_set_with_limit_index(&jo1, "/fud/gaw", jo2, limit_index)); /* re-using jo2 from above */
+	// ownership of jo2 transferred into jo1
+
+	jo2 = json_object_new_int(0);
+	assert(0 != json_pointer_set_with_limit_index(&jo1, "/fud/gaw/0", jo2, limit_index));
+	json_object_put(jo2);
+	jo2 = json_object_new_int(0);
+	assert(0 != json_pointer_set_with_limit_index(&jo1, "/fud/gaw/", jo2, limit_index));
+	json_object_put(jo2);
+	printf("PASSED - SET_WITH_LIMIT - failed to set index to non-array\n");
+
+	// assert(0 == json_pointer_setf(&jo1, json_object_new_string("cod"), "%s", "\0"));
+
+	json_object_put(jo1);
+
+    // testing with limit_index
+    jo1 = json_tokener_parse("{'foo': ['bar', 'baz']}");
+
+    errno = 0;
+    jo2 = json_object_new_string("out_of_bounds");
+    assert(0 != json_pointer_set_with_limit_index(&jo1, "/foo/20", jo2, limit_index));
+    assert(errno == EINVAL);
+    printf("PASSED - SET_LIMIT - Failed to set index 20 with limit 10\n");
+    // The value object was not consumed, so we must put it.
+    json_object_put(jo2);
+
+    // corner case: setting an index that equals the limit (should be ok, as it's idx > max_idx)
+    errno = 0;
+    assert(0 == json_pointer_set_with_limit_index(&jo1, "/foo/10", json_object_new_string("at_the_limit"), limit_index));
+    printf("PASSED - SET_LIMIT - Succeeded to set index 10 with limit 10\n");
+
+    json_object_put(jo1);
+}
+
+// callback for testing json_pointer_set_with_cb()
+static int test_cb_print_msg(json_object *parent, const char *key, size_t idx,
+                            json_object *value, void *priv)
+{
+    printf("PASSED - SET_WITH_CB - This callback is called\n");
+    return 0;
+}
+
+// callback for testing json_pointer_set_with_cb() with rejection logic
+static int test_cb_reject_logic(json_object *parent, const char *key, size_t idx,
+                            	json_object *value, void *priv)
+{
+    // Reject any operation if the key is "reject"
+    if (key && strcmp(key, "reject") == 0)
+    {
+        printf("PASSED - SET_WITH_CB - Callback correctly identified key 'reject' to reject\n");
+        return -1;
+    }
+    return 0;
+}
+
+static void test_set_with_cb(void)
+{
+    struct json_object *jo1 = json_tokener_parse(input_json_str);
+    size_t limit_index = 5;
+
+	assert(jo1 != NULL);
+	printf("PASSED - SET_WITH_CB - LOADED TEST JSON\n");
+	printf("%s\n", json_object_get_string(jo1));
+
+    assert(0 == json_pointer_set_with_cb(&jo1, "/foo/1", json_object_new_string("cod"), test_cb_print_msg, 1, NULL));
+    printf("PASSED - SET_WITH_CB - callback test_cb_print_msg for /foo/1\n");
+
+	assert(0 == json_pointer_set_with_cb(&jo1, "/foo/4", json_object_new_string("in"), json_object_array_put_with_idx_limit_cb, 0, &limit_index));
+    printf("PASSED - SET_WITH_CB - callback json_object_array_put_with_idx_limit_cb for /foo/4 with limit_index 5\n");
+
+    assert(0 == json_pointer_set_with_cb(&jo1, "/foo/5", json_object_new_string("border"), json_object_array_put_with_idx_limit_cb, 0, &limit_index));
+    printf("PASSED - SET_WITH_CB - failed with callback json_object_array_put_with_idx_limit_cb for /foo/5 with limit_index 5\n");
+
+    assert(0 != json_pointer_set_with_cb(&jo1, "/foo/10", json_object_new_string("out"), json_object_array_put_with_idx_limit_cb, 0, &limit_index));
+    assert(errno == EINVAL);
+    printf("PASSED - SET_WITH_CB - failed with callback json_object_array_put_with_idx_limit_cb for /foo/10 with limit_index 5\n");
+
+    assert(0 != json_pointer_set_with_cb(&jo1, "/foo/2", json_object_new_string("null_priv"), json_object_array_put_with_idx_limit_cb, 0, NULL));
+    assert(errno == EFAULT);
+    printf("PASSED - SET_WITH_CB - failed with callback json_object_array_put_with_idx_limit_cb with NULL priv\n");
+
+	json_object_put(jo1);
+
+	jo1 = json_tokener_parse("{'foo': 'bar'}");
+    assert(jo1 != NULL);
+
+	assert(0 == json_pointer_set_with_cb(&jo1, "/foo", json_object_new_string("cod"), test_cb_print_msg, 1, NULL));
+    printf("PASSED - SET_WITH_CB - cb_handles_obj=1: callback was triggered for object operation\n");
+
+	assert(0 == json_pointer_set_with_cb(&jo1, "/new_key", json_object_new_string("new_value"), test_cb_print_msg, 0, NULL));
+    printf("PASSED - SET_WITH_CB - cb_handles_obj=0: callback was NOT triggered for object operation, default logic was used\n");
+    json_object_put(jo1);
+
+	// testing rejection logic callback
+    jo1 = json_tokener_parse("{'data': {} }");
+    assert(jo1 != NULL);
+
+    assert(0 == json_pointer_set_with_cb(&jo1, "/data/accept", json_object_new_string("accepted_value"), test_cb_reject_logic, 1, NULL));
+    printf("PASSED - SET_WITH_CB - Rejection callback approved an allowed key\n");
+
+    assert(0 != json_pointer_set_with_cb(&jo1, "/data/reject", json_object_new_string("rejected_value"), test_cb_reject_logic, 1, NULL));
+    printf("PASSED - SET_WITH_CB - Rejection callback rejected a forbidden key\n");
+
+    json_object_put(jo1);
+}
+
+int main(int argc, char **argv)
+{
+    test_example_set_with_limit_index();
+    test_wrong_inputs_set_with_limit_index();
+    test_set_with_cb();
+	return 0;
+}

--- a/tests/test_safe_json_pointer_set.expected
+++ b/tests/test_safe_json_pointer_set.expected
@@ -1,0 +1,36 @@
+PASSED - SET_WITH_LIMIT - LOADED TEST JSON
+{ "foo": [ "bar", "baz" ], "": 0, "a\/b": 1, "c%d": 2, "e^f": 3, "g|h": 4, "i\\j": 5, "k\"l": 6, " ": 7, "m~n": 8 }
+PASSED - SET_WITH_LIMIT - 'cod' in /foo/1
+PASSED - SET_WITH_LIMIT - non-existing /fud/gaw
+PASSED - SET_WITH_LIMIT - /fud == {}
+PASSED - SET_WITH_LIMIT - /fug/gaw == [1,2,3]
+PASSED - SET_WITH_LIMIT - /fug/gaw == [0,2,3]
+PASSED - SET_WITH_LIMIT - /fug/gaw == [0,2,3,4]
+PASSED - SET_WITH_LIMIT - / == 9
+PASSED - SET_WITH_LIMIT - Final JSON is: { "foo": [ "bar", "cod" ], "": 9, "a\/b": 1, "c%d": 2, "e^f": 3, "g|h": 4, "i\\j": 5, "k\"l": 6, " ": 7, "m~n": 8, "fud": { "gaw": [ 0, 2, 3, 4 ] } }
+10
+PASSED - SET_LIMIT - Set value within limit (/foo/1 with limit 10)
+PASSED - SET_LIMIT - Set value on an object (limit is ignored)
+PASSED - SET_LIMIT - Set value with limit_index = -1 (no limit)
+PASSED - SET_WITH_LIMIT - LOADED TEST JSON
+{ "foo": [ "bar", "baz" ], "": 0, "a\/b": 1, "c%d": 2, "e^f": 3, "g|h": 4, "i\\j": 5, "k\"l": 6, " ": 7, "m~n": 8 }
+PASSED - SET_WITH_LIMIT - failed with NULL params for input json & path
+PASSED - SET_WITH_LIMIT - failed 'cod' with path 'foo/bar'
+PASSED - SET_WITH_LIMIT - failed with invalid array index'
+PASSED - SET_WITH_LIMIT - failed to set index to non-array
+PASSED - SET_LIMIT - Failed to set index 20 with limit 10
+PASSED - SET_LIMIT - Succeeded to set index 10 with limit 10
+PASSED - SET_WITH_CB - LOADED TEST JSON
+{ "foo": [ "bar", "baz" ], "": 0, "a\/b": 1, "c%d": 2, "e^f": 3, "g|h": 4, "i\\j": 5, "k\"l": 6, " ": 7, "m~n": 8 }
+PASSED - SET_WITH_CB - This callback is called
+PASSED - SET_WITH_CB - callback test_cb_print_msg for /foo/1
+PASSED - SET_WITH_CB - callback json_object_array_put_with_idx_limit_cb for /foo/4 with limit_index 5
+PASSED - SET_WITH_CB - failed with callback json_object_array_put_with_idx_limit_cb for /foo/5 with limit_index 5
+PASSED - SET_WITH_CB - failed with callback json_object_array_put_with_idx_limit_cb for /foo/10 with limit_index 5
+PASSED - SET_WITH_CB - failed with callback json_object_array_put_with_idx_limit_cb with NULL priv
+PASSED - SET_WITH_CB - This callback is called
+PASSED - SET_WITH_CB - cb_handles_obj=1: callback was triggered for object operation
+PASSED - SET_WITH_CB - cb_handles_obj=0: callback was NOT triggered for object operation, default logic was used
+PASSED - SET_WITH_CB - Rejection callback approved an allowed key
+PASSED - SET_WITH_CB - Callback correctly identified key 'reject' to reject
+PASSED - SET_WITH_CB - Rejection callback rejected a forbidden key

--- a/tests/test_safe_json_pointer_set.test
+++ b/tests/test_safe_json_pointer_set.test
@@ -1,0 +1,1 @@
+test_basic.test


### PR DESCRIPTION
Hi, An OOM vulnerability exists in the `json_pointer_set` function (and related functions). See issue #916 for more details.

To fix that, added a sanity check in the `is_valid_index` function to limit the maximum value of a parsed array index. Also provided a configurable macro for modification.