### PR TITLE
Fix build with clang-21

### DIFF
--- a/tests/test_deep_nesting.c
+++ b/tests/test_deep_nesting.c
@@ -15,8 +15,7 @@
 
 #define NESTING_DEPTH 100000
 
-static char *generate_json_string(void);
-static char *generate_json_string()
+static char *generate_json_string(void)
 {
 	char *str;
 	int depth = NESTING_DEPTH;
@@ -27,7 +26,6 @@ static char *generate_json_string()
 	return str;
 }
 
-static void test_deep_nesting_put(const char *str);
 static void test_deep_nesting_put(const char *str)
 {
 	json_object *my_array;
@@ -42,7 +40,6 @@ static void test_deep_nesting_put(const char *str)
 	json_tokener_free(tok);
 }
 
-static void test_deep_nesting_tostring(const char *str);
 static void test_deep_nesting_tostring(const char *str)
 {
 	json_object *my_array;


### PR DESCRIPTION
This patch fixes the build error with clang-21
  tests/test_deep_nesting.c:19:34: error: a function declaration
  without a prototype is deprecated in all versions of C
  [-Werror,-Wstrict-prototypes]
   19 | static char *generate_json_string()

by fixing generate_json_string() definition.

It also removes prototypes for static functions that are not needed.