### PR TITLE
ci: set least-privilege GITHUB_TOKEN permissions for meson workflow

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${{github.workflow}}-${{github.head_ref}}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   Linux-GCC:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## What

Adds a workflow-level `permissions: { contents: read }` block to `.github/workflows/meson.yml`.

## Why

By default, workflows without an explicit `permissions:` block run with the broad default `GITHUB_TOKEN` scopes. The meson workflow only checks out the repo and runs build/test across platforms — no job writes to the repository, packages, releases, or any other GitHub resource. Restricting the token to `contents: read` follows the principle of least privilege and limits the blast radius if any build/test step (or a dependency it pulls in) were compromised. This matches the GitHub-recommended and OpenSSF Scorecard "Token-Permissions" hardening guidance.

## Scope

- Single file, additive only: one top-level `permissions` block.
- No change to triggers, jobs, steps, or action versions.
- YAML validated; `git diff --check` clean.

---
*Disclosure: I used AI assistance while preparing this change. The diff is small and I have reviewed it for correctness.*