### PR TITLE
Nullify _userdata after _user_delete callback

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -301,8 +301,10 @@ static inline int _json_object_put_maybe_free(struct json_object *jso, int free_
 		return 0;  // All done, caller doesn't need to do anything else
 	}
 
-	if (jso->_user_delete)
+	if (jso->_user_delete) {
 		jso->_user_delete(jso, jso->_userdata);
+		jso->_userdata = NULL;
+	}
 
 	switch (jso->o_type)
 	{

--- a/json_object.c
+++ b/json_object.c
@@ -303,7 +303,9 @@ static inline int _json_object_put_maybe_free(struct json_object *jso, int free_
 
 	if (jso->_user_delete)
 		jso->_user_delete(jso, jso->_userdata);
-
+	
+    jso->_user_delete = NULL; // to avoid second call
+	
 	switch (jso->o_type)
 	{
 	case json_type_object: 


### PR DESCRIPTION
Nullify _userdata after callback _user_delete is applied.

```c
if (jso->_user_delete) {
	jso->_user_delete(jso, jso->_userdata);
	jso->_userdata = NULL;
}
```

This prevents _json_object_put_maybe_free() during a final assert of json_object_put() to pass a danglin pointer. 
```c
assert(_json_object_put_maybe_free(jso, 1) == 0);
```
Maybe its even better to hand over more control to the user by passing userdata by reference [as suggested here](https://github.com/json-c/json-c/pull/937):

```c
typedef void(json_object_delete_fn)(struct json_object *jso, void **userdata);
```

This addresses the [issue 934](https://github.com/json-c/json-c/issues/934)