### PR TITLE
free objects outside assert() in json_object_put

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -435,11 +435,16 @@ int json_object_put(struct json_object *jso)
 		// All slots are cleared, now pop back up to the parent
 		{
 			json_object *parent = jso->_delete_parent;
+			int rc;
 			// jso is a child that's already been detached from its parent
 			// so we need to actually free it now
 			assert(jso->_ref_count == 0);
 			jso->_ref_count++;   // We're the exclusive owner of jso, non-atomic add is ok.
-			assert(_json_object_put_maybe_free(jso, 1) == 0);
+			// Note: the call must not be inside assert(), or it gets
+			// compiled out when NDEBUG is defined and the memory leaks.
+			rc = _json_object_put_maybe_free(jso, 1);
+			assert(rc == 0);
+			(void)rc;
 			jso = parent;
 			// iteration will be reset at the top of the loop
 		}


### PR DESCRIPTION
json_object_put frees each non-empty container on the way back up its iterative teardown by calling _json_object_put_maybe_free(jso, 1) inside an assert(). Under NDEBUG, which is the default for release and most distro builds, assert() expands to nothing and the call is never evaluated, so every object/array node in the tree (along with its lh_table/array_list) leaks. I confirmed it with the leaks tool on a small nested document: 16 allocations leaked when built with -DNDEBUG, none with asserts on. The test suite builds with asserts enabled so it doesn't show up there. Evaluate the call into a local first and assert on that instead, so the free always happens.