### PR TITLE
meson: wire up `disable_extra_libs` option

### DIFF
--- a/RELEASE_CHECKLIST.txt
+++ b/RELEASE_CHECKLIST.txt
@@ -75,6 +75,9 @@ library version.  Generally, unless we're doing a major release, change:
 to
 	VERSION x.y+1.z
 
+        Update the version in meson.build (both at the top, and down under
+        '# Build library')
+
     git commit -a -m "Bump version to ${release}"
 
 If we're doing a major release (SONAME bump), also bump the version

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,8 @@ conf_data = configuration_data()
 jconf_data = configuration_data()
 conf_data.set('VERSION', meson.project_version())
 
+libjson_deps = []
+
 has_std_lib = cc.has_header('stdlib.h')
 has_std_arg = cc.has_header('stdarg.h')
 has_string = cc.has_header('string.h')
@@ -20,10 +22,7 @@ if has_std_lib and has_std_arg and has_string and has_float
   conf_data.set('STDC_HEADERS', 1, description : 'Define to 1 if you have the ANSI C header files.')
 endif
 
-bsd_dep = dependency('libbsd', required: false)
-
 headers = {
-  'bsd/stdlib.h': bsd_dep,
   'dlfcn.h': [],
   'endian.h': [],
   'fcntl.h': [],
@@ -47,6 +46,15 @@ headers = {
   'xlocale.h': [],
 }
 
+may_need_libbsd = true
+if cc.has_function('arc4random')
+  may_need_libbsd = false
+  conf_data.set('HAVE_@0@'.format('arc4random'.underscorify().to_upper()), 1, description :  'Define to 1 if you have the <@0@> header file'.format('arc4random'))
+else
+  bsd_dep = dependency('libbsd', required: get_option('extra_libs'))
+  headers += { 'bsd/stdlib.h': [bsd_dep] }
+endif
+
 foreach h, d : headers
   if cc.has_header(h, dependencies: d)
     conf_data.set('HAVE_@0@'.format(h.underscorify().to_upper()), 1, description :  'Define to 1 if you have the <@0@> header file'.format(h))
@@ -63,29 +71,35 @@ if cc.has_header('stdint.h')
   jconf_data.set('JSON_C_HAVE_STDINT_H', 1, description : 'Define to 1 if you have the <stdint.h> header file.')
 endif
 
-funcs = [
-  'open',
-  'realloc',
-  'setlocale',
-  'strdup',
-  'strerror',
-  'uselocale',
-  'duplocale',
-  'vsyslog',
-  'getrandom',
-  'getrusage',
-  'strtoll',
-  'strtoull',
-  'arc4random',
-  'vasprintf',
-]
+funcs = {
+  'open': [],
+  'realloc': [],
+  'setlocale': [],
+  'strdup': [],
+  'strerror': [],
+  'uselocale': [],
+  'duplocale': [],
+  'vsyslog': [],
+  'getrandom': [],
+  'getrusage': [],
+  'strtoll': [],
+  'strtoull': [],
+  'vasprintf': [],
+}
 
-if conf_data.has('HAVE_STRINGS_H')
-  funcs += ['strcasecmp', 'strncasecmp']
+if may_need_libbsd
+  funcs += { 'arc4random': [bsd_dep] }
+  libjson_deps += [bsd_dep]
+else
+  funcs += { 'arc4random': [] }
 endif
 
-foreach f : funcs
-  if cc.has_function(f)
+if conf_data.has('HAVE_STRINGS_H')
+  funcs += {'strcasecmp': [], 'strncasecmp': []}
+endif
+
+foreach f, d : funcs
+  if cc.has_function(f, dependencies: d)
     conf_data.set('HAVE_@0@'.format(f.to_upper()), 1, description : 'Define to 1 if you have the `@0@` function.'.format(f))
   endif
 endforeach
@@ -255,7 +269,7 @@ inc = include_directories('.')
 libjson = library('json-c',
   sources,
   include_directories: inc,
-  dependencies: bsd_dep,
+  dependencies: libjson_deps,
   install: true,
   link_args: sym,
   version: '5.4.0',

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,7 @@ if has_std_lib and has_std_arg and has_string and has_float
 endif
 
 headers = {
+  'bsd/stdlib.h': [],
   'dlfcn.h': [],
   'endian.h': [],
   'fcntl.h': [],
@@ -46,15 +47,6 @@ headers = {
   'xlocale.h': [],
 }
 
-may_need_libbsd = true
-if cc.has_function('arc4random')
-  may_need_libbsd = false
-  conf_data.set('HAVE_@0@'.format('arc4random'.underscorify().to_upper()), 1, description :  'Define to 1 if you have the <@0@> header file'.format('arc4random'))
-else
-  bsd_dep = dependency('libbsd', required: get_option('extra_libs'))
-  headers += { 'bsd/stdlib.h': [bsd_dep] }
-endif
-
 foreach h, d : headers
   if cc.has_header(h, dependencies: d)
     conf_data.set('HAVE_@0@'.format(h.underscorify().to_upper()), 1, description :  'Define to 1 if you have the <@0@> header file'.format(h))
@@ -71,7 +63,16 @@ if cc.has_header('stdint.h')
   jconf_data.set('JSON_C_HAVE_STDINT_H', 1, description : 'Define to 1 if you have the <stdint.h> header file.')
 endif
 
+bsd_dep = []
+if get_option('extra_libs')
+    _bsd_dep = dependency('libbsd', required: false)
+    if _bsd_dep.found()
+      bsd_dep = [ _bsd_dep ]
+    endif
+endif
+
 funcs = {
+  'arc4random': bsd_dep,
   'open': [],
   'realloc': [],
   'setlocale': [],
@@ -87,20 +88,19 @@ funcs = {
   'vasprintf': [],
 }
 
-if may_need_libbsd
-  funcs += { 'arc4random': [bsd_dep] }
-  libjson_deps += [bsd_dep]
-else
-  funcs += { 'arc4random': [] }
-endif
-
 if conf_data.has('HAVE_STRINGS_H')
   funcs += {'strcasecmp': [], 'strncasecmp': []}
 endif
 
+
 foreach f, d : funcs
-  if cc.has_function(f, dependencies: d)
+  if cc.has_function(f)
     conf_data.set('HAVE_@0@'.format(f.to_upper()), 1, description : 'Define to 1 if you have the `@0@` function.'.format(f))
+  else
+    if d.length() > 0 and cc.has_function(f, dependencies: d)
+        conf_data.set('HAVE_@0@'.format(f.to_upper()), 1, description : 'Define to 1 if you have the `@0@` function.'.format(f))
+        libjson_deps += d
+    endif
   endif
 endforeach
 

--- a/meson.build
+++ b/meson.build
@@ -297,19 +297,11 @@ endif
 install_headers(installed_headers, subdir: 'json-c')
 
 # pkg-config file
-configure_file(
-  input: 'json-c.pc.in',
-  output: 'json-c.pc',
-  install: true,
-  install_dir: get_option('libdir') / 'pkgconfig',
-  configuration: {
-    'prefix': get_option('prefix'),
-    'exec_prefix': get_option('prefix'),
-    'libdir': get_option('libdir'),
-    'includedir': get_option('includedir'),
-    'VERSION': meson.project_version(),
-    'LIBS': '',
-  }
+pkg = import('pkgconfig')
+pkg.generate(
+  libjson,
+  description: 'A JSON implementation in C',
+  subdirs: 'json-c',
 )
 
 # Optional apps

--- a/meson.build
+++ b/meson.build
@@ -317,7 +317,4 @@ if get_option('build_apps') and host_machine.system() != 'windows'
   subdir('apps')
 endif
 
-# Optional tests
-if get_option('buildtype') == 'debug'
-  subdir('tests')
-endif 
+subdir('tests')

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 
-project('json-c', 'c', version: '0.18.99',
+project('json-c', 'c', version: '0.19.99',
   meson_version: '>=0.54.0',
   license: 'MIT',
   default_options: ['buildtype=release', 'warning_level=2'])
@@ -272,7 +272,7 @@ libjson = library('json-c',
   dependencies: libjson_deps,
   install: true,
   link_args: sym,
-  version: '5.4.0',
+  version: '5.5.0',
   soversion: '5',
 )
 

--- a/meson.build
+++ b/meson.build
@@ -265,6 +265,10 @@ endif
 # Include directories
 inc = include_directories('.')
 
+# Math library (needed for INFINITY, isnan, etc.)
+m_dep = cc.find_library('m', required: false)
+libjson_deps += [m_dep]
+
 # Build library
 libjson = library('json-c',
   sources,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,7 +4,7 @@ option('disable_thread_local_storage', type: 'boolean', value: false, descriptio
 option('enable_rdrand', type: 'boolean', value: false, description: 'Enable RDRAND Hardware RNG')
 option('enable_threading', type: 'boolean', value: false, description: 'Enable partial threading support')
 option('override_get_random_seed', type: 'boolean', value: false, description: 'Override json_c_get_random_seed()')
-option('disable_extra_libs', type: 'boolean', value: false, description: 'Avoid linking extra libraries like libbsd')
+option('extra_libs', type: 'feature', value: 'enabled', description: 'Allow linking extra libraries like libbsd')
 option('disable_json_pointer', type: 'boolean', value: false, description: 'Disable JSON pointer support')
 option('disable_json_patch', type: 'boolean', value: false, description: 'Disable JSON patch support')
 option('newlocale_needs_freelocale', type: 'boolean', value: false, description: 'FreeBSD workaround for newlocale')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,7 +4,7 @@ option('disable_thread_local_storage', type: 'boolean', value: false, descriptio
 option('enable_rdrand', type: 'boolean', value: false, description: 'Enable RDRAND Hardware RNG')
 option('enable_threading', type: 'boolean', value: false, description: 'Enable partial threading support')
 option('override_get_random_seed', type: 'boolean', value: false, description: 'Override json_c_get_random_seed()')
-option('extra_libs', type: 'feature', value: 'enabled', description: 'Allow linking extra libraries like libbsd')
+option('extra_libs', type: 'boolean', value: true, description: 'Allow linking extra libraries like libbsd')
 option('disable_json_pointer', type: 'boolean', value: false, description: 'Disable JSON pointer support')
 option('disable_json_patch', type: 'boolean', value: false, description: 'Disable JSON patch support')
 option('newlocale_needs_freelocale', type: 'boolean', value: false, description: 'FreeBSD workaround for newlocale')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4,6 +4,7 @@ test_lib = static_library(
   objects: libjson.extract_all_objects(
     recursive: false,
   ),
+  build_by_default: false,
   install: false,
 )
 
@@ -65,7 +66,8 @@ foreach t : test_cases
   name = t[0]
   expected = t[1]
   exe = executable(name, name + '.c',
-    dependencies: test_deps
+    dependencies: test_deps,
+    build_by_default: false
   )
 
   test(name, exe,


### PR DESCRIPTION
This is more elegant as a meson feature option because feature options
propagate in a useful way to `
dependency(..., required: ...)`.

Without this, the option was ignored. Wiring it up naively meant that
disabling it still searched for libbsd as well, so a feature option
is the best fit.