### PR TITLE
reject empty reference token as array index in json_pointer

### DIFF
--- a/json_pointer.c
+++ b/json_pointer.c
@@ -46,6 +46,12 @@ static void string_replace_all_occurrences_with_char(char *s, const char *occur,
 static int is_valid_index(const char *path, size_t *idx)
 {
 	size_t i, len = strlen(path);
+	/* an empty reference token is never a valid array index */
+	if (len == 0)
+	{
+		errno = EINVAL;
+		return 0;
+	}
 	/* this code-path optimizes a bit, for when we reference the 0-9 index range
 	 * in a JSON array and because leading zeros not allowed
 	 */

--- a/tests/test_json_pointer.c
+++ b/tests/test_json_pointer.c
@@ -203,6 +203,10 @@ static void test_wrong_inputs_get(void)
 	assert(0 != json_pointer_get(jo1, "/foo/01", NULL));
 	assert(errno == EINVAL);
 	errno = 0;
+	/* An empty reference token is not a valid array index */
+	assert(0 != json_pointer_get(jo1, "/foo/", NULL));
+	assert(errno == EINVAL);
+	errno = 0;
 	assert(0 != json_pointer_getf(jo1, NULL, "/%s/a", "foo"));
 	assert(errno == EINVAL);
 	errno = 0;
@@ -312,6 +316,10 @@ static void test_wrong_inputs_set(void)
 
 	assert(0 != json_pointer_set(&jo1, "0", (jo2 = json_object_new_string("cod"))));
 	printf("PASSED - SET - failed with invalid array index'\n");
+	json_object_put(jo2);
+
+	assert(0 != json_pointer_set(&jo1, "/foo/", (jo2 = json_object_new_string("cod"))));
+	printf("PASSED - SET - failed with empty array index'\n");
 	json_object_put(jo2);
 
 	jo2 = json_object_new_string("whatever");

--- a/tests/test_json_pointer.expected
+++ b/tests/test_json_pointer.expected
@@ -36,4 +36,5 @@ PASSED - SET - failed with NULL params for input json & path
 PASSED - SET - failed 'cod' with path 'foo/bar'
 PASSED - SET - failed 'cod' with path 'foo/bar'
 PASSED - SET - failed with invalid array index'
+PASSED - SET - failed with empty array index'
 PASSED - SET - failed to set index to non-array


### PR DESCRIPTION
is_valid_index treats a zero-length reference token as valid and hands back index 0, since the empty string skips the single-digit fast path, is not caught by the leading-zero check, and then falls through to strtoull on an empty string. The practical effect is that a pointer like "/" or "/a/" against an array silently resolves to element 0 rather than failing, and because json_patch_apply goes through the same helper an RFC 6902 document with a path of "/" will replace or remove the first element instead of being rejected. Rejecting the empty token with EINVAL at the top of is_valid_index covers both the get and set call sites; empty-string object keys are unaffected, as the helper is only consulted for arrays.