### PR TITLE
Proper pkgconfig with meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 
-project('json-c', 'c', version: '0.18.99',
+project('json-c', 'c', version: '0.19.99',
   meson_version: '>=0.54.0',
   license: 'MIT',
   default_options: ['buildtype=release', 'warning_level=2'])
@@ -251,11 +251,14 @@ endif
 # Include directories
 inc = include_directories('.')
 
+# Math library (needed for INFINITY, isnan, etc.)
+m_dep = cc.find_library('m', required: false)
+
 # Build library
 libjson = library('json-c',
   sources,
   include_directories: inc,
-  dependencies: bsd_dep,
+  dependencies: [bsd_dep, m_dep],
   install: true,
   link_args: sym,
   version: '5.4.0',
@@ -287,6 +290,7 @@ pkg = import('pkgconfig')
 pkg.generate(
   libjson,
   description: 'A JSON implementation in C',
+  libraries_private: m_dep,
   subdirs: 'json-c',
 )
 

--- a/meson.build
+++ b/meson.build
@@ -265,7 +265,7 @@ libjson = library('json-c',
 jsonc_dep = declare_dependency(link_with: libjson, include_directories: inc)
 meson.override_dependency('json-c', jsonc_dep)
 
-# Install headers into json-c/ subdirectory (matches CMake layout)
+# Install headers
 installed_headers = [
   'arraylist.h', 'debug.h', 'json_c_version.h', 'json_inttypes.h',
   'json_object.h', 'json_object_iterator.h', 'json_tokener.h',
@@ -283,19 +283,11 @@ endif
 install_headers(installed_headers, subdir: 'json-c')
 
 # pkg-config file
-configure_file(
-  input: 'json-c.pc.in',
-  output: 'json-c.pc',
-  install: true,
-  install_dir: get_option('libdir') / 'pkgconfig',
-  configuration: {
-    'prefix': get_option('prefix'),
-    'exec_prefix': get_option('prefix'),
-    'libdir': get_option('libdir'),
-    'includedir': get_option('includedir'),
-    'VERSION': meson.project_version(),
-    'LIBS': '',
-  }
+pkg = import('pkgconfig')
+pkg.generate(
+  libjson,
+  description: 'A JSON implementation in C',
+  subdirs: 'json-c',
 )
 
 # Optional apps


### PR DESCRIPTION
Per my discussion with @eli-schwartz on #943, I implemented the generation of the `json-c.pc` file incorrectly.

This is the correct way to generate it using the pkgconfig module in meson which handles this in a much more correct and simpler way.

When comparing to the CMake generated output, I also noticed a missing `-lm` dependency in the `json-c.pc` file so this also corrects that error/inconsistency.

This method is part of what is in progress on #948 as well, however that draft is not completed and I wanted to get this correct solution in place ASAP.