### PR TITLE
Implementing extra_libs for linux

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,7 +20,11 @@ if has_std_lib and has_std_arg and has_string and has_float
   conf_data.set('STDC_HEADERS', 1, description : 'Define to 1 if you have the ANSI C header files.')
 endif
 
-bsd_dep = dependency('libbsd', required: false)
+extra_libs = get_option('extra_libs')
+bsd_dep = disabler()
+if not extra_libs.disabled()
+  bsd_dep = dependency('libbsd', required: false)
+endif
 
 headers = {
   'bsd/stdlib.h': bsd_dep,
@@ -76,7 +80,6 @@ funcs = [
   'getrusage',
   'strtoll',
   'strtoull',
-  'arc4random',
   'vasprintf',
 ]
 
@@ -95,6 +98,24 @@ foreach f : ['snprintf', 'vsnprintf', 'vprintf']
     conf_data.set('HAVE_@0@'.format(f.to_upper()), 1, description : 'Define to 1 if you have the `@0@` function.'.format(f))
   endif
 endforeach
+
+# arc4random() is provided by libc on BSDs, but on some Linux libc versions it is
+# only available via libbsd. Only try libbsd when extra_libs is enabled.
+arc4random_found = false
+arc4random_dep = disabler()
+if cc.has_function('arc4random', prefix : '#include <stdlib.h>')
+  arc4random_found = true
+elif not extra_libs.disabled()
+  if cc.has_header('bsd/stdlib.h', dependencies: bsd_dep) and cc.has_function('arc4random', prefix : '#include <bsd/stdlib.h>', dependencies: bsd_dep)
+    conf_data.set('HAVE_BSD_STDLIB_H', 1, description : 'Define to 1 if you have the <bsd/stdlib.h> header file.')
+    arc4random_dep = bsd_dep
+    arc4random_found = true
+  endif
+endif
+
+if arc4random_found
+  conf_data.set('HAVE_ARC4RANDOM', 1, description : 'Define to 1 if you have the `arc4random` function.')
+endif
 
 if not conf_data.has('HAVE_VPRINTF') and cc.has_function('_doprnt')
   conf_data.set('HAVE_DOPRNT', 1, description : 'Define to 1 if you have _doprnt but not vprintf.')
@@ -258,7 +279,7 @@ m_dep = cc.find_library('m', required: false)
 libjson = library('json-c',
   sources,
   include_directories: inc,
-  dependencies: [bsd_dep, m_dep],
+  dependencies: [arc4random_dep, m_dep],
   install: true,
   link_args: sym,
   version: '5.4.0',
@@ -290,7 +311,7 @@ pkg = import('pkgconfig')
 pkg.generate(
   libjson,
   description: 'A JSON implementation in C',
-  libraries_private: m_dep,
+  libraries_private: [m_dep, arc4random_dep],
   subdirs: 'json-c',
 )
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 
-project('json-c', 'c', version: '0.18.99',
+project('json-c', 'c', version: '0.19.99',
   meson_version: '>=0.54.0',
   license: 'MIT',
   default_options: ['buildtype=release', 'warning_level=2'])
@@ -251,11 +251,14 @@ endif
 # Include directories
 inc = include_directories('.')
 
+# Math library (needed for INFINITY, isnan, etc.)
+m_dep = cc.find_library('m', required: false)
+
 # Build library
 libjson = library('json-c',
   sources,
   include_directories: inc,
-  dependencies: bsd_dep,
+  dependencies: [bsd_dep, m_dep],
   install: true,
   link_args: sym,
   version: '5.4.0',
@@ -287,6 +290,7 @@ pkg = import('pkgconfig')
 pkg.generate(
   libjson,
   description: 'A JSON implementation in C',
+  libraries_private: m_dep,
   subdirs: 'json-c',
 )
 

--- a/meson.build
+++ b/meson.build
@@ -265,7 +265,7 @@ libjson = library('json-c',
 jsonc_dep = declare_dependency(link_with: libjson, include_directories: inc)
 meson.override_dependency('json-c', jsonc_dep)
 
-# Install headers into json-c/ subdirectory (matches CMake layout)
+# Install headers
 installed_headers = [
   'arraylist.h', 'debug.h', 'json_c_version.h', 'json_inttypes.h',
   'json_object.h', 'json_object_iterator.h', 'json_tokener.h',
@@ -283,19 +283,11 @@ endif
 install_headers(installed_headers, subdir: 'json-c')
 
 # pkg-config file
-configure_file(
-  input: 'json-c.pc.in',
-  output: 'json-c.pc',
-  install: true,
-  install_dir: get_option('libdir') / 'pkgconfig',
-  configuration: {
-    'prefix': get_option('prefix'),
-    'exec_prefix': get_option('prefix'),
-    'libdir': get_option('libdir'),
-    'includedir': get_option('includedir'),
-    'VERSION': meson.project_version(),
-    'LIBS': '',
-  }
+pkg = import('pkgconfig')
+pkg.generate(
+  libjson,
+  description: 'A JSON implementation in C',
+  subdirs: 'json-c',
 )
 
 # Optional apps

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,7 +4,7 @@ option('disable_thread_local_storage', type: 'boolean', value: false, descriptio
 option('enable_rdrand', type: 'boolean', value: false, description: 'Enable RDRAND Hardware RNG')
 option('enable_threading', type: 'boolean', value: false, description: 'Enable partial threading support')
 option('override_get_random_seed', type: 'boolean', value: false, description: 'Override json_c_get_random_seed()')
-option('disable_extra_libs', type: 'boolean', value: false, description: 'Avoid linking extra libraries like libbsd')
+option('extra_libs', type: 'feature', value: 'enabled', description: 'Allow linking extra libraries like libbsd')
 option('disable_json_pointer', type: 'boolean', value: false, description: 'Disable JSON pointer support')
 option('disable_json_patch', type: 'boolean', value: false, description: 'Disable JSON patch support')
 option('newlocale_needs_freelocale', type: 'boolean', value: false, description: 'FreeBSD workaround for newlocale')


### PR DESCRIPTION
This PR improves Meson handling of extra_libs for arc4random detection and fallback behavior, building on the work discussed in #948.

# What changed

- Replaced disable_extra_libs (boolean) with extra_libs (feature).
- Wired the option into detection/link behavior (it previously did not control the fallback path).
- Switched to capability-first detection for arc4random:

1. Check for arc4random in system libc first.
2. If not found, and extra_libs is enabled, check bsd/stdlib.h + libbsd.

- Made libbsd usage conditional on actually taking the fallback path, so it is not linked/exported unnecessarily.
- Kept pkg-config output aligned with link behavior by only including fallback private libs when used.

# Why

Different platforms/`libc`s provide arc4random differently:

- BSD libc: typically provides it directly.
- Newer glibc: may provide it directly.
- Some Linux/musl environments: may require fallback behavior.
- This ordering preserves native libc behavior when available and only uses libbsd as an opt-in fallback.

# Behavior impact

- If libc provides arc4random, it is used.
- If libc does not provide it, fallback to libbsd is attempted only when extra_libs is enabled.
- If fallback is not available, existing non-arc4random seed paths remain in place.

# Validation
Tested with:

- glibc environment where arc4random is available in libc.
- musl environment where arc4random is not available in libc.
- BSD targets continue to work correctly due to libc-first detection order.

# Context

Related draft: #948
This approach aims to keep the same goal while making the detection and dependency behavior more explicit and conditional.

@eli-schwartz @thesamesam, does this direction look better than the draft approach in #948?