### PR TITLE
reject leading zeros in strict-mode number parsing

### DIFF
--- a/json_tokener.c
+++ b/json_tokener.c
@@ -1043,6 +1043,22 @@ struct json_object *json_tokener_parse_ex(struct json_tokener *tok, const char *
 				tok->st_pos = 0;
 				goto redo_char;
 			}
+			if (tok->flags & JSON_TOKENER_STRICT)
+			{
+				/* RFC 8259 forbids leading zeros in the integer part:
+				 * a '0' may only be followed by '.', 'e'/'E' or the end
+				 * of the number, so "01", "00" and "-0123" are invalid
+				 * while "0", "-0" and "0.5" remain valid.
+				 */
+				const char *num = tok->pb->buf;
+				if (*num == '-')
+					num++;
+				if (num[0] == '0' && num[1] >= '0' && num[1] <= '9')
+				{
+					tok->err = json_tokener_error_parse_number;
+					goto out;
+				}
+			}
 			if (tok->is_double && !(tok->flags & JSON_TOKENER_STRICT))
 			{
 				/* Trim some chars off the end, to allow things
@@ -1083,12 +1099,6 @@ struct json_object *json_tokener_parse_ex(struct json_tokener *tok, const char *
 				         json_parse_uint64(tok->pb->buf, &numuint64) == 0)
 				{
 					if (errno == ERANGE && (tok->flags & JSON_TOKENER_STRICT))
-					{
-						tok->err = json_tokener_error_parse_number;
-						goto out;
-					}
-					if (numuint64 && tok->pb->buf[0] == '0' &&
-					    (tok->flags & JSON_TOKENER_STRICT))
 					{
 						tok->err = json_tokener_error_parse_number;
 						goto out;

--- a/tests/test_parse.c
+++ b/tests/test_parse.c
@@ -366,6 +366,15 @@ struct incremental_step
     {"12{", 3, 2, json_tokener_success, 1, 0},
     /* Parse number in strict mode */
     {"[02]", -1, 3, json_tokener_error_parse_number, 1, JSON_TOKENER_STRICT},
+    /* Leading zeros are rejected in strict mode, for every sign and type ... */
+    {"[00]", -1, 3, json_tokener_error_parse_number, 1, JSON_TOKENER_STRICT},
+    {"[-00]", -1, 4, json_tokener_error_parse_number, 1, JSON_TOKENER_STRICT},
+    {"[-01]", -1, 4, json_tokener_error_parse_number, 1, JSON_TOKENER_STRICT},
+    {"[-0123]", -1, 6, json_tokener_error_parse_number, 1, JSON_TOKENER_STRICT},
+    {"[01.5]", -1, 5, json_tokener_error_parse_number, 1, JSON_TOKENER_STRICT},
+    /* ... but a lone zero, "-0" and a zero before the fraction stay valid. */
+    {"[-0]", -1, -1, json_tokener_success, 1, JSON_TOKENER_STRICT},
+    {"[0.5]", -1, -1, json_tokener_success, 1, JSON_TOKENER_STRICT},
 
     {"0e+0", 5, 4, json_tokener_success, 1, 0},
     {"[0e+0]", -1, -1, json_tokener_success, 1, 0},

--- a/tests/test_parse.expected
+++ b/tests/test_parse.expected
@@ -156,6 +156,13 @@ json_tokener_parse_ex(tok, 1           ,   1) ... OK: got correct error: continu
 json_tokener_parse_ex(tok, 2           ,   2) ... OK: got object of type [int]: 12
 json_tokener_parse_ex(tok, 12{         ,   3) ... OK: got object of type [int]: 12
 json_tokener_parse_ex(tok, [02]        ,   4) ... OK: got correct error: number expected
+json_tokener_parse_ex(tok, [00]        ,   4) ... OK: got correct error: number expected
+json_tokener_parse_ex(tok, [-00]       ,   5) ... OK: got correct error: number expected
+json_tokener_parse_ex(tok, [-01]       ,   5) ... OK: got correct error: number expected
+json_tokener_parse_ex(tok, [-0123]     ,   7) ... OK: got correct error: number expected
+json_tokener_parse_ex(tok, [01.5]      ,   6) ... OK: got correct error: number expected
+json_tokener_parse_ex(tok, [-0]        ,   4) ... OK: got object of type [array]: [ 0 ]
+json_tokener_parse_ex(tok, [0.5]       ,   5) ... OK: got object of type [array]: [ 0.5 ]
 json_tokener_parse_ex(tok, 0e+0        ,   5) ... OK: got object of type [double]: 0e+0
 json_tokener_parse_ex(tok, [0e+0]      ,   6) ... OK: got object of type [array]: [ 0e+0 ]
 json_tokener_parse_ex(tok, 0e          ,   2) ... OK: got correct error: continue
@@ -368,5 +375,5 @@ json_tokener_parse_ex(tok, {"":1}     ,   7) ... OK: got correct error: invalid
 json_tokener_parse_ex(tok, {"":1}     ,   7) ... OK: got correct error: invalid string sequence
 json_tokener_parse_ex(tok, {"":1}     ,   7) ... OK: got correct error: invalid string sequence
 json_tokener_parse_ex(tok, {"":1}     ,   7) ... OK: got correct error: invalid string sequence
-End Incremental Tests OK=272 ERROR=0
+End Incremental Tests OK=279 ERROR=0
 ==================================


### PR DESCRIPTION
When the tokener is put into strict mode it is meant to reject numbers that don't follow RFC 8259, and leading zeros are one of the things the grammar disallows. The existing guard only covered positive non-zero integers though, because it keyed off `numuint64 && buf[0]=='0'`, so a zero value like "00" slipped through (its parsed value is 0), as did every negative integer such as "-01" or "-0123" and any double with a leading zero in its integer part like "00.5" or "01.5". I noticed it while checking how "[02]" is handled and then trying the negative and double variants, which all parsed happily in strict mode. The check now runs once on the assembled number: after an optional '-', a '0' immediately followed by another digit is rejected, so "0", "-0" and "0.5" stay valid while the malformed forms are refused. I removed the old positive-only guard since the new one subsumes it, and added the strict cases to the incremental parse tests.