### PR TITLE
reject negative after whitespace in json_parse_uint64

### DIFF
--- a/json_util.c
+++ b/json_util.c
@@ -263,7 +263,13 @@ int json_parse_uint64(const char *buf, uint64_t *retval)
 	uint64_t val;
 
 	errno = 0;
-	while (*buf == ' ')
+	/* strtoull() skips leading whitespace and then quietly negates a
+	 * leading '-', wrapping the result into a huge value. We only skipped
+	 * spaces here, so a '-' behind a tab/newline/etc slipped past the check
+	 * below. Skip the same whitespace set strtoull() does so the rejection
+	 * actually holds. */
+	while (*buf == ' ' || *buf == '\t' || *buf == '\n' || *buf == '\v' || *buf == '\f' ||
+	       *buf == '\r')
 		buf++;
 	if (*buf == '-')
 		return 1; /* error: uint cannot be negative */

--- a/tests/test_parse_int64.c
+++ b/tests/test_parse_int64.c
@@ -145,6 +145,11 @@ int main(int argc, char **argv)
 	strcpy(buf, "-9223372036854775808");
 	checkit_uint(buf);
 
+	// A negative value hidden behind non-space whitespace must still be
+	// rejected; strtoull() skips this whitespace and would wrap the '-'.
+	strcpy(buf, "\t-1");
+	checkit_uint(buf);
+
 	strcpy(buf, "   1");
 	checkit_uint(buf);
 

--- a/tests/test_parse_int64.expected
+++ b/tests/test_parse_int64.expected
@@ -41,6 +41,7 @@ buf=1 parseit=0, value=1
 buf=2147483647 parseit=0, value=2147483647 
 buf=-1 parseit=1, value=666 
 buf=-9223372036854775808 parseit=1, value=666 
+buf=	-1 parseit=1, value=666 
 buf=   1 parseit=0, value=1 
 buf=00001234 parseit=0, value=1234 
 buf=0001234x parseit=0, value=1234 


### PR DESCRIPTION
json_parse_uint64 only skips a leading space before rejecting a '-', but strtoull skips the whole whitespace set and then quietly negates the sign, so a value like "\t-1" (or one behind a newline, carriage return, form feed or vertical tab) slips past the guard and comes back as a wrapped near-UINT64_MAX value instead of an error. The same path is reachable from a JSON string through json_object_get_uint64, so a document controlling that string can turn a negative into a huge unsigned result. This skips the same whitespace strtoull does so the existing '-' rejection actually holds, with a regression case for the tab form added to test_parse_int64.