### PR TITLE
Fix test_json_parse_cli

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,9 +38,10 @@ set(ALL_TEST_NAMES
     test_visit
     test_object_iterator)
 
-set(NOBUILD_TEST_NAMES
-    test_json_parse_cli
-)
+set(NOBUILD_TEST_NAMES "")
+if (BUILD_APPS)
+  set(NOBUILD_TEST_NAMES ${NOBUILD_TEST_NAMES} test_json_parse_cli)
+endif()
 
 if (NOT DISABLE_JSON_POINTER)
     set(ALL_TEST_NAMES ${ALL_TEST_NAMES} test_json_pointer)

--- a/tests/test_json_parse_cli.test
+++ b/tests/test_json_parse_cli.test
@@ -10,7 +10,7 @@ fi
 
 set -x -v
 
-echo -n '"tenant=blue;note=CANARY_STACK_WINDOW_2026;status=ok"' > file1.dat
+printf '%s' '"tenant=blue;note=CANARY_STACK_WINDOW_2026;status=ok"' > file1.dat
 (printf '"' ; printf 'A%.0s' $(seq 1 16) ; echo 'e2'  | xxd -r -p) > file2.dat
 
 TESTNAME="${0##*/}"


### PR DESCRIPTION
The `test_json_parse_cli` test uses `json_parse` which is only compiled when `BUILD_APPS` is ON. So this test should not be run when `BUILD_APPS` is OFF. 

Additionally the `echo -n` behaves differently on some systems, causing the echo arguments to end up in the output stream. `printf` gives more consistent behaviour.